### PR TITLE
Fix incorrect paths in legacy test files

### DIFF
--- a/src/test/legacy/aggregateQueryTests.js
+++ b/src/test/legacy/aggregateQueryTests.js
@@ -23,7 +23,7 @@
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig"),
     Stream = require("stream"),

--- a/src/test/legacy/authorizationTests.js
+++ b/src/test/legacy/authorizationTests.js
@@ -24,7 +24,7 @@ SOFTWARE.
 "use strict";
 
 var assert = require("assert"),
-    lib = require("../..//"),
+    lib = require("../../../../../"),
     testConfig = require("./_testConfig.js"),
     DocumentBase = lib.DocumentBase,
     UriFactory = lib.UriFactory;

--- a/src/test/legacy/collectionNamingTest.js
+++ b/src/test/legacy/collectionNamingTest.js
@@ -23,7 +23,7 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig.js"),
     Stream = require("stream"),

--- a/src/test/legacy/documentClientTests.js
+++ b/src/test/legacy/documentClientTests.js
@@ -23,7 +23,7 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     testConfig = require("./_testConfig"),
     assert = require("assert");
 

--- a/src/test/legacy/encodingTests.js
+++ b/src/test/legacy/encodingTests.js
@@ -23,7 +23,7 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig"),
     DocumentDBClient = lib.DocumentClient,

--- a/src/test/legacy/incrementalFeedTests.js
+++ b/src/test/legacy/incrementalFeedTests.js
@@ -23,7 +23,7 @@
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig");
 

--- a/src/test/legacy/proxyTests.js
+++ b/src/test/legacy/proxyTests.js
@@ -26,7 +26,7 @@
 var http = require("http"),
     net = require("net"),
     url = require("url"),
-    lib = require("../..//"),
+    lib = require("../../../../../"),
     testConfig = require("./_testConfig");
 
 var Base = lib.Base,

--- a/src/test/legacy/queryTests.js
+++ b/src/test/legacy/queryTests.js
@@ -1,6 +1,6 @@
 ﻿"use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig"),
     DocumentDBClient = lib.DocumentClient,

--- a/src/test/legacy/rangePartitionResolverTests.js
+++ b/src/test/legacy/rangePartitionResolverTests.js
@@ -23,7 +23,7 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert");
 
 var Range = lib.Range,

--- a/src/test/legacy/rangeTests.js
+++ b/src/test/legacy/rangeTests.js
@@ -23,7 +23,7 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert");
 
 var Range = lib.Range;

--- a/src/test/legacy/ruPerMinTests.js
+++ b/src/test/legacy/ruPerMinTests.js
@@ -23,7 +23,7 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig");
 

--- a/src/test/legacy/sessionTests.js
+++ b/src/test/legacy/sessionTests.js
@@ -23,7 +23,7 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig"),
     sinon = require("sinon"),

--- a/src/test/legacy/splitTests.js
+++ b/src/test/legacy/splitTests.js
@@ -23,12 +23,12 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig"),
     Stream = require("stream"),
     util = require("util"),
-    HeaderUtils = require("../..//queryExecutionContext/headerUtils"), // TODO: shouldn't be using the direct path, use lib.HeaderUtils
+    HeaderUtils = require("../../../../../queryExecutionContext/headerUtils"), // TODO: shouldn't be using the direct path, use lib.HeaderUtils
     spawn = require("child_process").spawnSync,
     exec = require("child_process").execFileSync,
     _ = require('underscore');

--- a/src/test/legacy/sslVerificationTests.js
+++ b/src/test/legacy/sslVerificationTests.js
@@ -23,7 +23,7 @@
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert");
 
 var Base = lib.Base,

--- a/src/test/legacy/test.js
+++ b/src/test/legacy/test.js
@@ -23,7 +23,7 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig"),
     Stream = require("stream");

--- a/src/test/legacy/uriFactoryTests.js
+++ b/src/test/legacy/uriFactoryTests.js
@@ -23,10 +23,10 @@ SOFTWARE.
 
 "use strict";
 
-var lib = require("../..//"),
+var lib = require("../../../../../"),
     assert = require("assert"),
     testConfig = require("./_testConfig"),
-    UriFactory = require("../..//").UriFactory, // TODO: Shouldn't be using direct path
+    UriFactory = require("../../../../../").UriFactory, // TODO: Shouldn't be using direct path
     DocumentDBClient = lib.DocumentClient;
 
 var host = testConfig.host;


### PR DESCRIPTION
I saw in https://github.com/Azure/azure-cosmos-js/pull/6 that these tests might get removed? In the short term, they are preventing me from running the rest of the tests suite since require is throwing