### PR TITLE
Add CODEOWNERS for all default reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @christopheranderson @southpolesteve @dharmas-cosmos @srinathnarayanan @kirankumarkolli @kirillg


### PR DESCRIPTION
This adds default reviewers for all PRs.

I've never used this feature of GitHub before, so it's definitely up for discussion. You can read the docs on how it works here: https://help.github.com/articles/about-codeowners/

Effectively, all folks listed in the base branch's CODEOWNERS file has to review the PR before it can be committed. All folks currently assigned to review this PR will be required if this is merged in.