### PR TITLE
Port over existing docs to TS files

### DIFF
--- a/src/CosmosClient.ts
+++ b/src/CosmosClient.ts
@@ -5,6 +5,10 @@ import { DocumentClient } from "./documentclient";
 import { DatabaseAccount } from "./documents";
 import { Response } from "./request";
 
+/**
+ * Provides a client-side logical representation of the Azure Cosmos DB database account.
+ * This client is used to configure and execute requests in the Azure Cosmos DB database service.
+ */
 export class CosmosClient {
     public readonly databases: Databases;
     public readonly offers: Offers;

--- a/src/CosmosClientOptions.ts
+++ b/src/CosmosClientOptions.ts
@@ -1,13 +1,20 @@
 import { ConnectionPolicy, ConsistencyLevel } from "./documents";
 
 export interface CosmosClientOptions {
+    /** The service endpoint to use to create the client. */
     endpoint: string;
+    /** An object that is used for authenticating requests and must contains one of the options */
     auth: {
+        /** The authorization master key to use to create the client. */
         masterKey?: string;
+        /** An array of {@link Permission} objects. */
         permissionFeed?: any; // TODO: any
+        /** An object that contains resources tokens. Keys for the object are resource Ids and values are the resource tokens. */
         resourceTokens?: any; // TODO: any
         tokenProvider?: any; // TODO: any
     };
+    /** An instance of {@link ConnectionPolicy} class. This parameter is optional and the default connectionPolicy will be used if omitted. */
     connectionPolicy?: ConnectionPolicy;
+    /** An optional parameter that represents the consistency level. It can take any value from {@link ConsistencyLevel}. */
     consistencyLevel?: ConsistencyLevel;
 }

--- a/src/DocumentClientBase.ts
+++ b/src/DocumentClientBase.ts
@@ -11,6 +11,7 @@ import { RequestOptions } from "./request/RequestOptions";
 import { SessionContainer } from "./sessionContainer";
 
 // Using this to organize public vs internal methods
+/** @hidden */
 export abstract class DocumentClientBase {
     public masterKey: string;
     public resourceTokens: { [key: string]: string };

--- a/src/client/Container/ContainerDefinition.ts
+++ b/src/client/Container/ContainerDefinition.ts
@@ -1,8 +1,12 @@
 import { IndexingPolicy, PartitionKey, PartitionKeyDefinition } from "../../documents";
 
 export interface ContainerDefinition {
+    /** The id of the container. */
     id?: string;
+    /**  TODO */
     partitionKey?: PartitionKeyDefinition;
+    /** The indexing policy associated with the container. */
     indexingPolicy?: IndexingPolicy;
+    /** The default time to live in seconds for items in a container. */
     defaultTtl?: number;
 }

--- a/src/client/Container/Containers.ts
+++ b/src/client/Container/Containers.ts
@@ -16,6 +16,18 @@ export class Containers {
         return this.database.client.documentClient.queryCollections(this.database.url, query, options);
     }
 
+    /**
+     * Creates a container.
+     * <p>
+     * A container is a named logical container for items. <br>
+     * A database may contain zero or more named containers and each container consists of \
+     * zero or more JSON items. <br>
+     * Being schema-free, the items in a container do not need to share the same structure or fields. <br>
+     * Since containers are application resources, they can be authorized using either the \
+     * master key or resource keys. <br>
+     * </p>
+     * @param body                          - Represents the body of the container.
+     */
     public create(body: ContainerDefinition, options?: RequestOptions): Promise<Response<ContainerDefinition>> {
         return this.database.client.documentClient.createCollection(this.database.url, body, options);
     }

--- a/src/client/Database/DatabaseDefinition.ts
+++ b/src/client/Database/DatabaseDefinition.ts
@@ -1,3 +1,4 @@
 export interface DatabaseDefinition {
+    /** The id of the database. */
     id?: string;
 }

--- a/src/client/Database/Databases.ts
+++ b/src/client/Database/Databases.ts
@@ -15,6 +15,19 @@ export class Databases {
         return this.client.documentClient.queryDatabases(query, options);
     }
 
+    /**
+     * Send a request for creating a database.
+     * <p>
+     *  A database manages users, permissions and a set of collections.  <br>
+     *  Each Azure Cosmos DB Database Account is able to support multiple independent named databases,\
+     *  with the database being the logical container for data. <br>
+     *  Each Database consists of one or more collections, each of which in turn contain one or more \
+     *  documents. Since databases are an an administrative resource, the Service Master Key will be \
+     * required in order to access and successfully complete any action using the User APIs. <br>
+     * </p>
+     *
+     * @param body              - A json object that represents The database to be created.
+     */
     public create(body: DatabaseDefinition, options?: RequestOptions): Promise<Response<DatabaseDefinition>> {
         return this.client.documentClient.createDatabase(body, options);
     }

--- a/src/client/Item/Items.ts
+++ b/src/client/Item/Items.ts
@@ -27,12 +27,28 @@ export class Items {
         return this.client.readDocuments(this.container.url, options) as QueryIterator<T>;
     }
 
+    /**
+     * Create a item.
+     * <p>
+     * There is no set schema for JSON items. They may contain any number of custom properties as \
+     * well as an optional list of attachments. <br>
+     * A item is an application resource and can be authorized using the master key or resource keys
+     * </p>
+     * @param body  - Represents the body of the item. Can contain any number of user defined properties.
+     */
     public async create(body: any, options?: RequestOptions): Promise<Response<any>>;
     public async create<T>(body: T, options?: RequestOptions): Promise<Response<T>>;
     public async create<T>(body: T, options?: RequestOptions): Promise<Response<T>> {
         return this.client.createDocument(this.container.url, body, options) as Promise<Response<T>>;
     }
 
+    /**
+     * Upsert an item.
+     * <p>
+     * There is no set schema for JSON items. They may contain any number of custom properties.<br>
+     * An Item is an application resource and can be authorized using the master key or resource keys
+     * </p>
+     */
     public async upsert(body: any, options?: RequestOptions): Promise<Response<any>>;
     public async upsert<T>(body: T, options?: RequestOptions): Promise<Response<T>>;
     public async upsert<T>(body: T, options?: RequestOptions): Promise<Response<T>> {

--- a/src/client/Permission/PermissionDefinition.ts
+++ b/src/client/Permission/PermissionDefinition.ts
@@ -1,8 +1,11 @@
 import { PermissionMode } from "../../documents";
 
 export interface PermissionDefinition {
+    /** The id of the permission */
     id?: string;
+    /** The mode of the permission, must be a value of {@link PermissionMode} */
     permissionMode: PermissionMode;
+    /** The link of the resource that the permission will be applied to. */
     resource: string;
     resourcePartitionKey?: string | any[]; // TODO: what's allowed here?
 }

--- a/src/client/Permission/Permissions.ts
+++ b/src/client/Permission/Permissions.ts
@@ -26,6 +26,15 @@ export class Permissions {
             .readPermissions(this.user.url, options) as QueryIterator<PermissionDefinition>;
     }
 
+    /**
+     * Create a permission.
+     * <p> A permission represents a per-User Permission to access a specific resource \
+     * e.g. Item or Container.  </p>
+     * @param body                 - Represents the body of the permission.
+     * @param {string} body.id              - The id of the permission
+     * @param {string} body.permissionMode  - The mode of the permission, must be a value of {@link PermissionMode}
+     * @param {string} body.resource        - The link of the resource that the permission will be applied to.
+     */
     public create(
         body: PermissionDefinition,
         options?: RequestOptions,
@@ -33,6 +42,11 @@ export class Permissions {
         return this.client.documentClient.createPermission(this.user.url, body, options);
     }
 
+    /**
+     * Upsert a permission.
+     * <p> A permission represents a per-User Permission to access a \
+     * specific resource e.g. Item or Cotnainer.  </p>
+     */
     public upsert(
         body: PermissionDefinition,
         options?: RequestOptions,

--- a/src/client/StoredProcedure/StoredProcedures.ts
+++ b/src/client/StoredProcedure/StoredProcedures.ts
@@ -23,6 +23,16 @@ export class StoredProcedures {
         return this.client.documentClient.readStoredProcedures(this.container.url, options);
     }
 
+    /**
+     * Create a StoredProcedure.
+     * <p>
+     * Azure Cosmos DB allows stored procedures to be executed in the storage tier, \
+     * directly against an item container. The script <br>
+     * gets executed under ACID transactions on the primary storage partition of the \
+     * specified container. For additional details, <br>
+     * refer to the server-side JavaScript API documentation.
+     * </p>
+     */
     public async create(
         body: StoredProcedureDefinition,
         options?: RequestOptions,
@@ -30,6 +40,16 @@ export class StoredProcedures {
         return this.client.documentClient.createStoredProcedure(this.container.url, body, options);
     }
 
+    /**
+     * Upsert a StoredProcedure.
+     * <p>
+     * Azure Cosmos DB allows stored procedures to be executed in the storage tier,
+     * directly against a document collection. The script <br>
+     * gets executed under ACID transactions on the primary storage partition of the
+     *  specified collection. For additional details, <br>
+     * refer to the server-side JavaScript API documentation.
+     * </p>
+     */
     public async upsert(
         body: StoredProcedureDefinition,
         options?: RequestOptions,

--- a/src/client/Trigger/TriggerDefinition.ts
+++ b/src/client/Trigger/TriggerDefinition.ts
@@ -2,7 +2,10 @@ import { TriggerOperation, TriggerType } from "../../documents";
 
 export interface TriggerDefinition {
     id?: string;
+    /** The body of the trigger, it can also be passed as a stringifed function */
     body: (() => void) | string;
+    /** The type of the trigger, should be one of the values of {@link TriggerType}. */
     triggerType: TriggerType;
+    /** The trigger operation, should be one of the values of {@link TriggerOperation}. */
     triggerOperation: TriggerOperation;
 }

--- a/src/client/Trigger/Triggers.ts
+++ b/src/client/Trigger/Triggers.ts
@@ -24,11 +24,26 @@ export class Triggers {
     public read(options?: FeedOptions): QueryIterator<TriggerDefinition> {
         return this.client.documentClient.readTriggers(this.container.url, options) as QueryIterator<TriggerDefinition>;
     }
-
+    /**
+     * Create a trigger.
+     * <p>
+     * Azure Cosmos DB supports pre and post triggers defined in JavaScript to be executed \
+     * on creates, updates and deletes. <br>
+     * For additional details, refer to the server-side JavaScript API documentation.
+     * </p>
+     */
     public create(body: TriggerDefinition, options?: RequestOptions): Promise<Response<TriggerDefinition>> {
         return this.client.documentClient.createTrigger(this.container.url, body, options);
     }
 
+    /**
+     * Upsert a trigger.
+     * <p>
+     * Azure Cosmos DB supports pre and post triggers defined in JavaScript to be
+     * executed on creates, updates and deletes. <br>
+     * For additional details, refer to the server-side JavaScript API documentation.
+     * </p>
+     */
     public upsert(body: TriggerDefinition, options?: RequestOptions): Promise<Response<TriggerDefinition>> {
         return this.client.documentClient.upsertTrigger(this.container.url, body, options);
     }

--- a/src/client/User/UserDefinition.ts
+++ b/src/client/User/UserDefinition.ts
@@ -1,3 +1,4 @@
 export interface UserDefinition {
+    /** The id of the user. */
     id?: string;
 }

--- a/src/client/User/Users.ts
+++ b/src/client/User/Users.ts
@@ -23,6 +23,10 @@ export class Users {
         return this.client.documentClient.readUsers(this.database.url, options);
     }
 
+    /**
+     * Create a database user.
+     * @param body                 - Represents the body of the user.
+     */
     public create(
         body: UserDefinition,
         options?: RequestOptions,

--- a/src/client/UserDefinedFunction/UserDefinedFunctionDefinition.ts
+++ b/src/client/UserDefinedFunction/UserDefinedFunctionDefinition.ts
@@ -1,4 +1,5 @@
 export interface UserDefinedFunctionDefinition {
     id?: string;
+    /** The body of the user defined function, it can also be passed as a stringifed function */
     body?: string | (() => void);
 }

--- a/src/client/UserDefinedFunction/UserDefinedFunctions.ts
+++ b/src/client/UserDefinedFunction/UserDefinedFunctions.ts
@@ -24,6 +24,13 @@ export class UserDefinedFunctions {
         return this.client.documentClient.readUserDefinedFunctions(this.container.url, options);
     }
 
+    /**
+     * Create a UserDefinedFunction.
+     * <p>
+     * Azure Cosmos DB supports JavaScript UDFs which can be used inside queries, stored procedures and triggers. <br>
+     * For additional details, refer to the server-side JavaScript API documentation.
+     * </p>
+     */
     public create(
         body: UserDefinedFunctionDefinition,
         options?: RequestOptions,
@@ -31,6 +38,13 @@ export class UserDefinedFunctions {
         return this.client.documentClient.createUserDefinedFunction(this.container.url, body, options);
     }
 
+    /**
+     * Upsert a UserDefinedFunction.
+     * <p>
+     * Azure Cosmos DB supports JavaScript UDFs which can be used inside queries, stored procedures and triggers. <br>
+     * For additional details, refer to the server-side JavaScript API documentation.
+     * </p>
+     */
     public upsert(
         body: UserDefinedFunctionDefinition,
         options?: RequestOptions,

--- a/src/documentclient.ts
+++ b/src/documentclient.ts
@@ -20,46 +20,8 @@ import { RequestOptions } from "./request/RequestOptions";
 import { RetryOptions } from "./retry";
 import { SessionContainer } from "./sessionContainer";
 
-// var Base = require("./base")
-//     , https = require("https")
-//     , url = require("url")
-//     , tunnel = require("tunnel")
-//     , AzureDocuments = require("./documents")
-//     , QueryIterator = require("./queryIterator")
-//     , RequestHandler = require("./request")
-//     , RetryOptions = require("./retryOptions")
-//     , GlobalEndpointManager = require("./globalEndpointManager")
-//     , Constants = require("./constants")
-//     , Helper = require("./helper").Helper
-//     , util = require("util")
-//     , Platform = require("./platform")
-//     , SessionContainer = require("./sessionContainer");
-
-// if (typeof exports !== "undefined") {
-//     exports.DocumentClient = DocumentClient;
-//     exports.DocumentBase = AzureDocuments;
-//     exports.RetryOptions = RetryOptions;
-//     exports.Base = Base;
-//     exports.Constants = Constants;
-// }
-
+/** @hidden */
 export class DocumentClient extends DocumentClientBase {
-    /**
-     * Provides a client-side logical representation of the Azure Cosmos DB database account.
-     * This client is used to configure and execute requests in the Azure Cosmos DB database service.
-     * @constructor DocumentClient
-     * @param {string} urlConnection           - The service endpoint to use to create the client.
-     * @param {object} auth                    - An object that is used for authenticating requests \
-     * and must contains one of the options
-     * @param {string} [auth.masterKey]        - The authorization master key to use to create the client.
-     * @param {Object} [auth.resourceTokens]   - An object that contains resources tokens. Keys for the \
-     * object are resource Ids and values are the resource tokens.
-     * @param {Array}  [auth.permissionFeed]   - An array of {@link Permission} objects.
-     * @param {object} [connectionPolicy]      - An instance of {@link ConnectionPolicy} class. This \
-     * parameter is optional and the default connectionPolicy will be used if omitted.
-     * @param {string} [consistencyLevel]      - An optional parameter that represents the consistency \
-     * level. It can take any value from {@link ConsistencyLevel}.
-     */
     constructor(
         public urlConnection: string,
         auth: any,
@@ -67,12 +29,8 @@ export class DocumentClient extends DocumentClientBase {
         consistencyLevel?: ConsistencyLevel) { // TODO: any auth options
         super(urlConnection, auth, connectionPolicy, consistencyLevel);
     }
-    /**
-     * Gets the curent write endpoint for a geo-replicated database account.
-     * @memberof DocumentClient
-     * @instance
-     * @param {function} callback        - The callback function which takes endpoint(string) as an argument.
-     */
+
+    // NOT USED IN NEW OM
     public async getWriteEndpoint(callback?: (writeEndPoint: string) => void): Promise<string> {
         const p = this._globalEndpointManager.getWriteEndpoint();
 
@@ -83,12 +41,7 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Gets the curent read endpoint for a geo-replicated database account.
-     * @memberof DocumentClient
-     * @instance
-     * @param {function} callback        - The callback function which takes endpoint(string) as an argument.
-     */
+    // NOT USED IN NEW OM
     public getReadEndpoint(callback?: (readEndPoint: string) => void): void | Promise<string> {
         const p = this._globalEndpointManager.getReadEndpoint();
 
@@ -99,23 +52,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Send a request for creating a database.
-     * <p>
-     *  A database manages users, permissions and a set of collections.  <br>
-     *  Each Azure Cosmos DB Database Account is able to support multiple independent named databases,\
-     *  with the database being the logical container for data. <br>
-     *  Each Database consists of one or more collections, each of which in turn contain one or more \
-     *  documents. Since databases are an an administrative resource, the Service Master Key will be \
-     * required in order to access and successfully complete any action using the User APIs. <br>
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {Object} body              - A json object that represents The database to be created.
-     * @param {string} body.id           - The id of the database.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {ResponseCallback<any>} callback - The callback for the request.
-     */
     public createDatabase(
         body: object,
         options?: RequestOptions,
@@ -134,27 +70,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.create(body, path, "dbs", undefined, undefined, options, callback);
     }
 
-    /**
-     * Creates a collection.
-     * <p>
-     * A collection is a named logical container for documents. <br>
-     * A database may contain zero or more named collections and each collection consists of \
-     * zero or more JSON documents. <br>
-     * Being schema-free, the documents in a collection do not need to share the same structure or fields. <br>
-     * Since collections are application resources, they can be authorized using either the \
-     * master key or resource keys. <br>
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink                  - The self-link of the database.
-     * @param {object} body                          - Represents the body of the collection.
-     * @param {string} body.id                       - The id of the collection.
-     * @param {IndexingPolicy} body.indexingPolicy   - The indexing policy associated with the collection.
-     * @param {number} body.defaultTtl               - The default time to live in seconds for documents in \
-     * a collection.
-     * @param {RequestOptions} [options]             - The request options.
-     * @param {ResponseCallback<any>} callback             - The callback for the request.
-     */
     public async createCollection(
         databaseLink: string,
         body: any,
@@ -182,31 +97,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Create a document.
-     * <p>
-     * There is no set schema for JSON documents. They may contain any number of custom properties as \
-     * well as an optional list of attachments. <br>
-     * A Document is an application resource and can be authorized using the master key or resource keys
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentsFeedOrDatabaseLink               - \
-     * The collection link or database link if using a partition resolver
-     * @param {object} body                                      - \
-     * Represents the body of the document. Can contain any number of user defined properties.
-     * @param {string} [body.id]                                 - \
-     * The id of the document, MUST be unique for each document.
-     * @param {number} body.ttl                                  - \
-     * The time to live in seconds of the document.
-     * @param {RequestOptions} [options]                         - \
-     * The request options.
-     * @param {boolean} [options.disableAutomaticIdGeneration]   - \
-     * Disables the automatic id generation. If id is missing in the body and this option is true, \
-     * an error will be returned.
-     * @param {ResponseCallback<Document>} callback                         - \
-     * The callback for the request.
-     */
     public async createDocument(
         documentsFeedOrDatabaseLink: string, // TODO: bad name
         body: any,
@@ -230,24 +120,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Create an attachment for the document object.
-     * <p>
-     * Each document may contain zero or more attachments. Attachments can be of any MIME type - \
-     * text, image, binary data. <br>
-     * These are stored externally in Azure Blob storage. Attachments are automatically \
-     * deleted when the parent document is deleted.
-     * </P>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentLink         - The self-link of the document.
-     * @param {Object} body                 - The metadata the defines the attachment media like media, \
-     * contentType. It can include any other properties as part of the metedata.
-     * @param {string} body.contentType     - The MIME contentType of the attachment.
-     * @param {string} body.media           - Media link associated with the attachment content.
-     * @param {RequestOptions} options      - The request options.
-     * @param {RequestCallback} callback    - The callback for the request.
-     */
     public async createAttachment(
         documentLink: string,
         body: any,
@@ -275,16 +147,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Create a database user.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink         - The self-link of the database.
-     * @param {object} body                 - Represents the body of the user.
-     * @param {string} body.id              - The id of the user.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {RequestCallback} callback    - The callback for the request.
-     */
     public async createUser(
         databaseLink: string,
         body: any,
@@ -312,20 +174,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Create a permission.
-     * <p> A permission represents a per-User Permission to access a specific resource \
-     * e.g. Document or Collection.  </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} userLink             - The self-link of the user.
-     * @param {object} body                 - Represents the body of the permission.
-     * @param {string} body.id              - The id of the permission
-     * @param {string} body.permissionMode  - The mode of the permission, must be a value of {@link PermissionMode}
-     * @param {string} body.resource        - The link of the resource that the permission will be applied to.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {ResponseCallback<any>} callback    - The callback for the request. Promise won't return response.
-     */
     public async createPermission(
         userLink: string,
         body: any,
@@ -352,26 +200,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Create a trigger.
-     * <p>
-     * Azure Cosmos DB supports pre and post triggers defined in JavaScript to be executed \
-     * on creates, updates and deletes. <br>
-     * For additional details, refer to the server-side JavaScript API documentation.
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink           - The self-link of the collection.
-     * @param {object} trigger                  - Represents the body of the trigger.
-     * @param {string} trigger.id             - The id of the trigger.
-     * @param {string} trigger.triggerType      - The type of the trigger, \
-     * should be one of the values of {@link TriggerType}.
-     * @param {string} trigger.triggerOperation - The trigger operation, \
-     * should be one of the values of {@link TriggerOperation}.
-     * @param {function} trigger.serverScript   - The body of the trigger, it can be passed as stringified too.
-     * @param {RequestOptions} [options]        - The request options.
-     * @param {RequestCallback} callback        - The callback for the request.
-     */
     public async createTrigger(
         collectionLink: string,
         trigger: any,
@@ -405,24 +233,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Create a UserDefinedFunction.
-     * <p>
-     * Azure Cosmos DB supports JavaScript UDFs which can be used inside queries, stored procedures and triggers. <br>
-     * For additional details, refer to the server-side JavaScript API documentation.
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink                - The self-link of the collection.
-     * @param {object} udf                           - Represents the body of the userDefinedFunction.
-     * @param {string} udf.id                      - The id of the udf.
-     * @param {string} udf.userDefinedFunctionType   - The type of the udf, it should be one of the values \
-     * of {@link UserDefinedFunctionType}
-     * @param {function} udf.serverScript            - Represents the body of the udf, it can be passed as \
-     * stringified too.
-     * @param {RequestOptions} [options]             - The request options.
-     * @param {RequestCallback} callback             - The callback for the request.
-     */
     public async createUserDefinedFunction(
         collectionLink: string,
         udf: any,
@@ -456,24 +266,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Create a StoredProcedure.
-     * <p>
-     * Azure Cosmos DB allows stored procedures to be executed in the storage tier, \
-     * directly against a document collection. The script <br>
-     * gets executed under ACID transactions on the primary storage partition of the \
-     * specified collection. For additional details, <br>
-     * refer to the server-side JavaScript API documentation.
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink       - The self-link of the collection.
-     * @param {object} sproc                - Represents the body of the stored procedure.
-     * @param {string} sproc.id           - The id of the stored procedure.
-     * @param {function} sproc.serverScript - The body of the stored procedure, it can be passed as stringified too.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {RequestCallback} callback    - The callback for the request.
-     */
     public async createStoredProcedure(
         collectionLink: string,
         sproc: any,
@@ -507,15 +299,7 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Create an attachment for the document object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentLink             - The self-link of the document.
-     * @param {Readable} readableStream  - the stream that represents the media itself that needs to be uploaded.
-     * @param {MediaOptions} [options]          - The request options.
-     * @param {ResponseCallback} callback        - The callback for the request.
-     */
+    // NOT USED IN NEW OM
     public async createAttachmentAndUploadMedia(
         documentLink: string,
         readableStream: Readable,
@@ -547,14 +331,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads a database.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink         - The self-link of the database.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {ResponseCallback} callback    - The callback for the request.
-     */
     public async readDatabase(
         databaseLink: string,
         options?: RequestOptions,
@@ -575,14 +351,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads a collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink       - The self-link of the collection.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {ResponseCallback} callback    - The callback for the request.
-     */
     public async readCollection(
         collectionLink: string,
         options?: RequestOptions,
@@ -604,14 +372,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads a document.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentLink         - The self-link of the document.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {ResponseCallback} callback    - The callback for the request.
-     */
     public async readDocument(
         documentLink: string,
         options?: RequestOptions,
@@ -631,14 +391,7 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads an Attachment object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} attachmentLink    - The self-link of the attachment.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {ResponseCallback} callback - The callback for the request.
-     */
+    // NOT USED IN NEW OM
     public async readAttachment(
         attachmentLink: string,
         options?: RequestOptions,
@@ -658,14 +411,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads a user.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} userLink          - The self-link of the user.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {ResponseCallback} callback - The callback for the request.
-     */
     public async readUser(
         userLink: string,
         options?: RequestOptions,
@@ -686,14 +431,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads a permission.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} permissionLink    - The self-link of the permission.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {ResponseCallback} callback - The callback for the request.
-     */
     public async readPermission(
         permissionLink: string,
         options?: RequestOptions,
@@ -714,14 +451,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads a trigger object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} triggerLink       - The self-link of the trigger.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {ResponseCallback} callback - The callback for the request.
-     */
     public async readTrigger(
         triggerLink: string,
         options?: RequestOptions,
@@ -744,14 +473,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads a udf object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} udfLink           - The self-link of the user defined function.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {ResponseCallback} callback - The callback for the request.
-     */
     public async readUserDefinedFunction(
         udfLink: string,
         options?: RequestOptions,
@@ -772,14 +493,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads a StoredProcedure object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} sprocLink         - The self-link of the stored procedure.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public async readStoredProcedure(
         sprocLink: string,
         options?: RequestOptions,
@@ -799,14 +512,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Reads a conflict.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} conflictLink      - The self-link of the conflict.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public async readConflict(
         conflictLink: string,
         options?: RequestOptions,
@@ -827,134 +532,47 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Lists all databases.
-     * @memberof DocumentClient
-     * @instance
-     * @param {FeedOptions} [options] - The feed options.
-     * @returns {QueryIterator}       - An instance of queryIterator to handle reading feed.
-     */
     public readDatabases(options?: FeedOptions) {
         return this.queryDatabases(undefined, options);
     }
 
-    /**
-     * Get all collections in this database.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink   - The self-link of the database.
-     * @param {FeedOptions} [options] - The feed options.
-     * @returns {QueryIterator}       - An instance of queryIterator to handle reading feed.
-     */
     public readCollections(databaseLink: string, options?: FeedOptions) {
         return this.queryCollections(databaseLink, undefined, options);
     }
 
-    /**
-     * Get all documents in this collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink - The self-link of the collection.
-     * @param {FeedOptions} [options] - The feed options.
-     * @returns {QueryIterator}       - An instance of queryIterator to handle reading feed.
-     */
     public readDocuments(collectionLink: string, options?: FeedOptions) {
         return this.queryDocuments(collectionLink, undefined, options);
     }
 
-    /**
-     * Get all Partition key Ranges in this collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink - The self-link of the collection.
-     * @param {FeedOptions} [options] - The feed options.
-     * @returns {QueryIterator}       - An instance of queryIterator to handle reading feed.
-     * @ignore
-     */
     public readPartitionKeyRanges(collectionLink: string, options?: FeedOptions) {
         return this.queryPartitionKeyRanges(collectionLink, undefined, options);
     }
 
-    /**
-     * Get all attachments for this document.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentLink   - The self-link of the document.
-     * @param {FeedOptions} [options] - The feed options.
-     * @returns {QueryIterator}       - An instance of queryIterator to handle reading feed.
-     */
+    // NOT USED IN NEW OM
     public readAttachments(documentLink: string, options?: FeedOptions) {
         return this.queryAttachments(documentLink, undefined, options);
     }
 
-    /**
-     * Get all users in this database.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink       - The self-link of the database.
-     * @param {FeedOptions} [feedOptions] - The feed options.
-     * @returns {QueryIterator}           - An instance of queryIterator to handle reading feed.
-     */
     public readUsers(databaseLink: string, options?: FeedOptions) {
         return this.queryUsers(databaseLink, undefined, options);
     }
 
-    /**
-     * Get all permissions for this user.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} userLink           - The self-link of the user.
-     * @param {FeedOptions} [feedOptions] - The feed options.
-     * @returns {QueryIterator}           - An instance of queryIterator to handle reading feed.
-     */
     public readPermissions(userLink: string, options?: FeedOptions) {
         return this.queryPermissions(userLink, undefined, options);
     }
 
-    /**
-     * Get all triggers in this collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink   - The self-link of the collection.
-     * @param {FeedOptions} [options]   - The feed options.
-     * @returns {QueryIterator}         - An instance of queryIterator to handle reading feed.
-     */
     public readTriggers(collectionLink: string, options?: FeedOptions) {
         return this.queryTriggers(collectionLink, undefined, options);
     }
 
-    /**
-     * Get all UserDefinedFunctions in this collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink - The self-link of the collection.
-     * @param {FeedOptions} [options] - The feed options.
-     * @returns {QueryIterator}       - An instance of queryIterator to handle reading feed.
-     */
     public readUserDefinedFunctions(collectionLink: string, options?: FeedOptions) {
         return this.queryUserDefinedFunctions(collectionLink, undefined, options);
     }
 
-    /**
-     * Get all StoredProcedures in this collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink - The self-link of the collection.
-     * @param {FeedOptions} [options] - The feed options.
-     * @returns {QueryIterator}       - An instance of queryIterator to handle reading feed.
-     */
     public readStoredProcedures(collectionLink: string, options?: FeedOptions) {
         return this.queryStoredProcedures(collectionLink, undefined, options);
     }
 
-    /**
-     * Get all conflicts in this collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink - The self-link of the collection.
-     * @param {FeedOptions} [options] - The feed options.
-     * @returns {QueryIterator}       - An instance of QueryIterator to handle reading feed.
-     */
     public readConflicts(collectionLink: string, options?: FeedOptions) {
         return this.queryConflicts(collectionLink, undefined, options);
     }
@@ -970,7 +588,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /** @ignore */
     public async queryFeed(
         documentclient: DocumentClient,
         path: string,
@@ -1036,14 +653,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Lists all databases that satisfy a query.
-     * @memberof DocumentClient
-     * @instance
-     * @param {SqlQuerySpec | string} query - A SQL query.
-     * @param {FeedOptions} [options]       - The feed options.
-     * @returns {QueryIterator}             - An instance of QueryIterator to handle reading feed.
-     */
     public queryDatabases(query: SqlQuerySpec | string, options?: FeedOptions) {
         const cb: FetchFunctionCallback = (innerOptions) => {
             return this.queryFeed(
@@ -1059,15 +668,6 @@ export class DocumentClient extends DocumentClientBase {
         return new QueryIterator(this, query, options, cb);
     }
 
-    /**
-     * Query the collections for the database.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink           - The self-link of the database.
-     * @param {SqlQuerySpec | string} query   - A SQL query.
-     * @param {FeedOptions} [options]         - Represents the feed options.
-     * @returns {QueryIterator}               - An instance of queryIterator to handle reading feed.
-     */
     public queryCollections(databaseLink: string, query: string | SqlQuerySpec, options?: FeedOptions) {
         const isNameBased = Base.isLinkNameBased(databaseLink);
         const path = this.getPathFromLink(databaseLink, "colls", isNameBased);
@@ -1086,18 +686,6 @@ export class DocumentClient extends DocumentClientBase {
         });
     }
 
-    /**
-     * Query the documents for the collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentsFeedOrDatabaseLink          -\
-     * The collection link or database link if using a partition resolver
-     * @param {SqlQuerySpec | string} query                 - A SQL query.
-     * @param {FeedOptions} [options]                       - Represents the feed options.
-     * @param {object} [options.partitionKey]               - \
-     * Optional partition key to be used with the partition resolver
-     * @returns {QueryIterator}                             - An instance of queryIterator to handle reading feed.
-     */
     public queryDocuments(documentsFeedOrDatabaseLink: string, query?: string | SqlQuerySpec, options?: FeedOptions) {
         const partitionResolver = this.partitionResolvers[documentsFeedOrDatabaseLink];
         const collectionLinks = (partitionResolver === undefined || partitionResolver === null)
@@ -1106,16 +694,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.queryDocumentsPrivate(collectionLinks, query, options);
     }
 
-    /**
-     * Query the partition key ranges
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink           - The self-link of the database.
-     * @param {SqlQuerySpec | string} query   - A SQL query.
-     * @param {FeedOptions} [options]         - Represents the feed options.
-     * @returns {QueryIterator}               - An instance of queryIterator to handle reading feed.
-     * @ignore
-     */
     public queryPartitionKeyRanges(collectionLink: string, query: string | SqlQuerySpec, options?: FeedOptions) {
         const isNameBased = Base.isLinkNameBased(collectionLink);
         const path = this.getPathFromLink(collectionLink, "pkranges", isNameBased);
@@ -1134,15 +712,7 @@ export class DocumentClient extends DocumentClientBase {
         });
     }
 
-    /**
-     * Query the attachments for the document.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentLink           - The self-link of the document.
-     * @param {SqlQuerySpec | string} query   - A SQL query.
-     * @param {FeedOptions} [options]         - Represents the feed options.
-     * @returns {QueryIterator}               - An instance of queryIterator to handle reading feed.
-     */
+    // NOT USED IN NEW OM
     public queryAttachments(documentLink: string, query: string | SqlQuerySpec, options?: FeedOptions) {
         const isNameBased = Base.isLinkNameBased(documentLink);
         const path = this.getPathFromLink(documentLink, "attachments", isNameBased);
@@ -1161,15 +731,6 @@ export class DocumentClient extends DocumentClientBase {
         });
     }
 
-    /**
-     * Query the users for the database.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink           - The self-link of the database.
-     * @param {SqlQuerySpec | string} query   - A SQL query.
-     * @param {FeedOptions} [options]         - Represents the feed options.
-     * @returns {QueryIterator}               - An instance of queryIterator to handle reading feed.
-     */
     public queryUsers(databaseLink: string, query: string | SqlQuerySpec, options?: FeedOptions) {
         const isNameBased = Base.isLinkNameBased(databaseLink);
         const path = this.getPathFromLink(databaseLink, "users", isNameBased);
@@ -1188,15 +749,6 @@ export class DocumentClient extends DocumentClientBase {
         });
     }
 
-    /**
-     * Query the permission for the user.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} userLink               - The self-link of the user.
-     * @param {SqlQuerySpec | string} query   - A SQL query.
-     * @param {FeedOptions} [options]         - Represents the feed options.
-     * @returns {QueryIterator}               - An instance of queryIterator to handle reading feed.
-     */
     public queryPermissions(userLink: string, query: string | SqlQuerySpec, options?: FeedOptions) {
         const isNameBased = Base.isLinkNameBased(userLink);
         const path = this.getPathFromLink(userLink, "permissions", isNameBased);
@@ -1215,15 +767,6 @@ export class DocumentClient extends DocumentClientBase {
         });
     }
 
-    /**
-     * Query the triggers for the collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink         - The self-link of the collection.
-     * @param {SqlQuerySpec | string} query   - A SQL query.
-     * @param {FeedOptions} [options]         - Represents the feed options.
-     * @returns {QueryIterator}               - An instance of queryIterator to handle reading feed.
-     */
     public queryTriggers(collectionLink: string, query: string | SqlQuerySpec, options?: FeedOptions) {
         const isNameBased = Base.isLinkNameBased(collectionLink);
         const path = this.getPathFromLink(collectionLink, "triggers", isNameBased);
@@ -1242,15 +785,6 @@ export class DocumentClient extends DocumentClientBase {
         });
     }
 
-    /**
-     * Query the user defined functions for the collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink         - The self-link of the collection.
-     * @param {SqlQuerySpec | string} query   - A SQL query.
-     * @param {FeedOptions} [options]         - Represents the feed options.
-     * @returns {QueryIterator}               - An instance of queryIterator to handle reading feed.
-     */
     public queryUserDefinedFunctions(collectionLink: string, query: string | SqlQuerySpec, options?: FeedOptions) {
         const isNameBased = Base.isLinkNameBased(collectionLink);
         const path = this.getPathFromLink(collectionLink, "udfs", isNameBased);
@@ -1269,15 +803,6 @@ export class DocumentClient extends DocumentClientBase {
         });
     }
 
-    /**
-     * Query the storedProcedures for the collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink         - The self-link of the collection.
-     * @param {SqlQuerySpec | string} query   - A SQL query.
-     * @param {FeedOptions} [options]         - Represents the feed options.
-     * @returns {QueryIterator}               - An instance of queryIterator to handle reading feed.
-     */
     public queryStoredProcedures(collectionLink: string, query: string | SqlQuerySpec, options?: FeedOptions) {
         const isNameBased = Base.isLinkNameBased(collectionLink);
         const path = this.getPathFromLink(collectionLink, "sprocs", isNameBased);
@@ -1296,15 +821,6 @@ export class DocumentClient extends DocumentClientBase {
         });
     }
 
-    /**
-     * Query the conflicts for the collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink         - The self-link of the collection.
-     * @param {SqlQuerySpec | string} query   - A SQL query.
-     * @param {FeedOptions} [options]         - Represents the feed options.
-     * @returns {QueryIterator}               - An instance of queryIterator to handle reading feed.
-     */
     public queryConflicts(collectionLink: string, query: string | SqlQuerySpec, options?: FeedOptions) {
         const isNameBased = Base.isLinkNameBased(collectionLink);
         const path = this.getPathFromLink(collectionLink, "conflicts", isNameBased);
@@ -1323,14 +839,6 @@ export class DocumentClient extends DocumentClientBase {
         });
     }
 
-    /**
-     * Delete the database object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink         - The self-link of the database.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {ResponseCallback<any>} callback    - The callback for the request.
-     */
     public deleteDatabase(
         databaseLink: string, options?: RequestOptions, callback?: ResponseCallback<any>): Promise<Response<any>> {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -1343,14 +851,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "dbs", id, undefined, options, callback);
     }
 
-    /**
-     * Delete the collection object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink    - The self-link of the collection.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public deleteCollection(collectionLink: string, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1363,14 +863,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "colls", id, undefined, options, callback);
     }
 
-    /**
-     * Delete the document object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentLink      - The self-link of the document.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public deleteDocument(documentLink: string, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1383,14 +875,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "docs", id, undefined, options, callback);
     }
 
-    /**
-     * Delete the attachment object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} attachmentLink    - The self-link of the attachment.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public deleteAttachment(attachmentLink: string, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1403,14 +887,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "attachments", id, undefined, options, callback);
     }
 
-    /**
-     * Delete the user object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} userLink          - The self-link of the user.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public deleteUser(userLink: string, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1423,14 +899,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "users", id, undefined, options, callback);
     }
 
-    /**
-     * Delete the permission object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} permissionLink    - The self-link of the permission.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public deletePermission(permissionLink: string, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1443,14 +911,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "permissions", id, undefined, options, callback);
     }
 
-    /**
-     * Delete the trigger object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} triggerLink       - The self-link of the trigger.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public deleteTrigger(triggerLink: string, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1463,14 +923,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "triggers", id, undefined, options, callback);
     }
 
-    /**
-     * Delete the UserDefinedFunction object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} udfLink           - The self-link of the user defined function.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public deleteUserDefinedFunction(udfLink: string, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1483,14 +935,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "udfs", id, undefined, options, callback);
     }
 
-    /**
-     * Delete the StoredProcedure object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} sprocLink         - The self-link of the stored procedure.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public deleteStoredProcedure(sprocLink: string, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1503,14 +947,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "sprocs", id, undefined, options, callback);
     }
 
-    /**
-     * Delete the conflict object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} conflictLink      - The self-link of the conflict.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public deleteConflict(conflictLink: string, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1523,15 +959,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.deleteResource(path, "conflicts", id, undefined, options, callback);
     }
 
-    /**
-     * Replace the document collection.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink    - The self-link of the document collection.
-     * @param {object} collection        - Represent the new document collection body.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public replaceCollection(
         collectionLink: string,
         collection: any,
@@ -1554,15 +981,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.replace(collection, path, "colls", id, undefined, options, callback);
     }
 
-    /**
-     * Replace the document object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentLink      - The self-link of the document.
-     * @param {object} document          - Represent the new document body.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {ResponseCallback} callback - The callback for the request.
-     */
     public async replaceDocument(
         documentLink: string,
         newDocument: any,
@@ -1595,15 +1013,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Replace the attachment object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} attachmentLink    - The self-link of the attachment.
-     * @param {object} attachment        - Represent the new attachment body.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public replaceAttachment(
         attachmentLink: string, attachment: any, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -1623,15 +1032,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.replace(attachment, path, "attachments", id, undefined, options, callback);
     }
 
-    /**
-     * Replace the user object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} userLink          - The self-link of the user.
-     * @param {object} user              - Represent the new user body.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public replaceUser(
         userLink: string, user: any, options?: RequestOptions, callback?: ResponseCallback<any>) { // TODO: any
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -1651,15 +1051,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.replace(user, path, "users", id, undefined, options, callback);
     }
 
-    /**
-     * Replace the permission object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} permissionLink    - The self-link of the permission.
-     * @param {object} permission        - Represent the new permission body.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public replacePermission(
         permissionLink: string, permission: any,
         options?: RequestOptions, callback?: ResponseCallback<any>) { // TODO: any
@@ -1680,15 +1071,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.replace(permission, path, "permissions", id, undefined, options, callback);
     }
 
-    /**
-     * Replace the trigger object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} triggerLink       - The self-link of the trigger.
-     * @param {object} trigger           - Represent the new trigger body.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public replaceTrigger(
         triggerLink: string, trigger: any, options?: RequestOptions, callback?: ResponseCallback<any>) { // TODO: any
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -1714,15 +1096,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.replace(trigger, path, "triggers", id, undefined, options, callback);
     }
 
-    /**
-     * Replace the UserDefinedFunction object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} udfLink           - The self-link of the user defined function.
-     * @param {object} udf               - Represent the new udf body.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public replaceUserDefinedFunction(
         udfLink: string, udf: any, options?: RequestOptions, callback?: ResponseCallback<any>) { // TODO: any
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -1748,15 +1121,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.replace(udf, path, "udfs", id, undefined, options, callback);
     }
 
-    /**
-     * Replace the StoredProcedure object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} sprocLink         - The self-link of the stored procedure.
-     * @param {object} sproc             - Represent the new sproc body.
-     * @param {RequestOptions} [options] - The request options.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public replaceStoredProcedure(
         sprocLink: string, sproc: any, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -1782,28 +1146,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.replace(sproc, path, "sprocs", id, undefined, options, callback);
     }
 
-    /**
-     * Upsert a document.
-     * <p>
-     * There is no set schema for JSON documents. They may contain any number of custom properties as \
-     * well as an optional list of attachments. <br>
-     * A Document is an application resource and can be authorized using the master key or resource keys
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentsFeedOrDatabaseLink               - \
-     * The collection link or database link if using a partition resolver
-     * @param {object} body                                      - \
-     * Represents the body of the document. Can contain any number of user defined properties.
-     * @param {string} [body.id]                                 - \
-     * The id of the document, MUST be unique for each document.
-     * @param {number} body.ttl                                  - The time to live in seconds of the document.
-     * @param {RequestOptions} [options]                         - The request options.
-     * @param {boolean} [options.disableAutomaticIdGeneration]   - \
-     * Disables the automatic id generation. If id is missing in the body and this option is true, an error \
-     * will be returned.
-     * @param {RequestCallback} callback                         - The callback for the request.
-     */
     public upsertDocument(
         documentsFeedOrDatabaseLink: string,
         body: any,
@@ -1818,25 +1160,7 @@ export class DocumentClient extends DocumentClientBase {
         return this.upsertDocumentPrivate(collectionLink, body, options, callback);
     }
 
-    /**
-     * Upsert an attachment for the document object.
-     * <p>
-     * Each document may contain zero or more attachments.
-     * Attachments can be of any MIME type - text, image, binary data. <br>
-     * These are stored externally in Azure Blob storage.
-     * Attachments are automatically deleted when the parent document is deleted.
-     * </P>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentLink         - The self-link of the document.
-     * @param {Object} body                 - \
-     * The metadata the defines the attachment media like media, contentType.
-     * It can include any other properties as part of the metedata.
-     * @param {string} body.contentType     - The MIME contentType of the attachment.
-     * @param {string} body.media           - Media link associated with the attachment content.
-     * @param {RequestOptions} options      - The request options.
-     * @param {RequestCallback} callback    - The callback for the request.
-     */
+    // NOT USED IN NEW OM
     public upsertAttachment(
         documentLink: string, body: any, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -1856,16 +1180,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.upsert(body, path, "attachments", id, undefined, options, callback);
     }
 
-    /**
-     * Upsert a database user.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} databaseLink         - The self-link of the database.
-     * @param {object} body                 - Represents the body of the user.
-     * @param {string} body.id              - The id of the user.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {RequestCallback} callback    - The callback for the request.
-     */
     public upsertUser(databaseLink: string, body: any, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1884,20 +1198,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.upsert(body, path, "users", id, undefined, options, callback);
     }
 
-    /**
-     * Upsert a permission.
-     * <p> A permission represents a per-User Permission to access a \
-     * specific resource e.g. Document or Collection.  </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} userLink             - The self-link of the user.
-     * @param {object} body                 - Represents the body of the permission.
-     * @param {string} body.id              - The id of the permission
-     * @param {string} body.permissionMode  - The mode of the permission, must be a value of {@link PermissionMode}
-     * @param {string} body.resource        - The link of the resource that the permission will be applied to.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {RequestCallback} callback    - The callback for the request.
-     */
     public upsertPermission(userLink: string, body: any, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
@@ -1916,26 +1216,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.upsert(body, path, "permissions", id, undefined, options, callback);
     }
 
-    /**
-     * Upsert a trigger.
-     * <p>
-     * Azure Cosmos DB supports pre and post triggers defined in JavaScript to be
-     * executed on creates, updates and deletes. <br>
-     * For additional details, refer to the server-side JavaScript API documentation.
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink           - The self-link of the collection.
-     * @param {object} trigger                  - Represents the body of the trigger.
-     * @param {string} trigger.id             - The id of the trigger.
-     * @param {string} trigger.triggerType      -
-     * The type of the trigger, should be one of the values of {@link TriggerType}.
-     * @param {string} trigger.triggerOperation -
-     * The trigger operation, should be one of the values of {@link TriggerOperation}.
-     * @param {function} trigger.serverScript   - The body of the trigger, it can be passed as stringified too.
-     * @param {RequestOptions} [options]        - The request options.
-     * @param {RequestCallback} callback        - The callback for the request.
-     */
     public upsertTrigger(
         collectionLink: string, trigger: any, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -1961,24 +1241,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.upsert(trigger, path, "triggers", id, undefined, options, callback);
     }
 
-    /**
-     * Upsert a UserDefinedFunction.
-     * <p>
-     * Azure Cosmos DB supports JavaScript UDFs which can be used inside queries, stored procedures and triggers. <br>
-     * For additional details, refer to the server-side JavaScript API documentation.
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink                - The self-link of the collection.
-     * @param {object} udf                           - Represents the body of the userDefinedFunction.
-     * @param {string} udf.id                      - The id of the udf.
-     * @param {string} udf.userDefinedFunctionType   -
-     * The type of the udf, it should be one of the values of {@link UserDefinedFunctionType}
-     * @param {function} udf.serverScript            -
-     * Represents the body of the udf, it can be passed as stringified too.
-     * @param {RequestOptions} [options]             - The request options.
-     * @param {RequestCallback} callback             - The callback for the request.
-     */
     public upsertUserDefinedFunction(
         collectionLink: string, udf: any, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -2004,24 +1266,6 @@ export class DocumentClient extends DocumentClientBase {
         return this.upsert(udf, path, "udfs", id, undefined, options, callback);
     }
 
-    /**
-     * Upsert a StoredProcedure.
-     * <p>
-     * Azure Cosmos DB allows stored procedures to be executed in the storage tier,
-     * directly against a document collection. The script <br>
-     * gets executed under ACID transactions on the primary storage partition of the
-     *  specified collection. For additional details, <br>
-     * refer to the server-side JavaScript API documentation.
-     * </p>
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} collectionLink       - The self-link of the collection.
-     * @param {object} sproc                - Represents the body of the stored procedure.
-     * @param {string} sproc.id           - The id of the stored procedure.
-     * @param {function} sproc.serverScript - The body of the stored procedure, it can be passed as stringified too.
-     * @param {RequestOptions} [options]    - The request options.
-     * @param {RequestCallback} callback    - The callback for the request.
-     */
     public upsertStoredProcedure(
         collectionLink: string, sproc: any, options?: RequestOptions, callback?: ResponseCallback<any>) {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
@@ -2047,15 +1291,7 @@ export class DocumentClient extends DocumentClientBase {
         return this.upsert(sproc, path, "sprocs", id, undefined, options, callback);
     }
 
-    /**
-     * Upsert an attachment for the document object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} documentLink             - The self-link of the document.
-     * @param {stream.Readable} readableStream  - the stream that represents the media itself that needs to be uploaded.
-     * @param {MediaOptions} [options]          - The request options.
-     * @param {RequestCallback} callback        - The callback for the request.
-     */
+    // NOT USED IN NEW OM
     public upsertAttachmentAndUploadMedia(
         documentLink: string, readableStream: Readable,
         options?: MediaOptions, callback?: ResponseCallback<any>) {
@@ -2080,15 +1316,7 @@ export class DocumentClient extends DocumentClientBase {
         return this.upsert(readableStream, path, "attachments", id, initialHeaders, options, callback);
     }
 
-    /**
-     * Read the media for the attachment object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} mediaLink         - The media link of the media in the attachment.
-     * @param {RequestCallback} callback -
-     * The callback for the request, the result parameter can be a buffer or a stream
-     *                                     depending on the value of {@link MediaReadMode}.
-     */
+    // NOT USED IN NEW OM
     public async readMedia(mediaLink: string, callback?: ResponseCallback<any>) {
         const resourceInfo = Base.parseLink(mediaLink);
         const path = mediaLink;
@@ -2107,15 +1335,7 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Update media for the attachment
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} mediaLink                - The media link of the media in the attachment.
-     * @param {stream.Readable} readableStream  - The stream that represents the media itself that needs to be uploaded.
-     * @param {MediaOptions} [options]          - options for the media
-     * @param {RequestCallback} callback        - The callback for the request.
-     */
+    // NOT USED IN NEW OM
     public async updateMedia(
         mediaLink: string, readableStream: Readable,
         options?: MediaOptions, callback?: ResponseCallback<any>): Promise<Response<any>> {
@@ -2152,15 +1372,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Execute the StoredProcedure represented by the object with partition key.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} sprocLink            - The self-link of the stored procedure.
-     * @param {Array} [params]              - represent the parameters of the stored procedure.
-     * @param {Object} [options]            - partition key
-     * @param {RequestCallback} callback    - The callback for the request.
-     */
     public async executeStoredProcedure(
         sprocLink: string, params?: any[], // TODO: any
         options?: RequestOptions, callback?: ResponseCallback<any>) {
@@ -2202,14 +1413,6 @@ export class DocumentClient extends DocumentClientBase {
         }
     }
 
-    /**
-     * Replace the offer object.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} offerLink         - The self-link of the offer.
-     * @param {object} offer             - Represent the new offer body.
-     * @param {RequestCallback} callback - The callback for the request.
-     */
     public replaceOffer(offerLink: string, offer: any, callback?: ResponseCallback<any>) {
         const err = {};
         if (!this.isResourceValid(offer, err)) {
@@ -2222,38 +1425,16 @@ export class DocumentClient extends DocumentClientBase {
         return this.replace(offer, path, "offers", id, undefined, {}, callback);
     }
 
-    /**
-     * Reads an offer.
-     * @memberof DocumentClient
-     * @instance
-     * @param {string} offerLink         - The self-link of the offer.
-     * @param {RequestCallback} callback    - The callback for the request.
-     */
     public async readOffer(offerLink: string, callback?: ResponseCallback<any>) {
         const path = "/" + offerLink;
         const id = Base.parseLink(offerLink).objectBody.id.toLowerCase();
         return Base.ResponseOrCallback(callback, await this.read(path, "offers", id, undefined, {}));
     }
 
-    /**
-     * Lists all offers.
-     * @memberof DocumentClient
-     * @instance
-     * @param {FeedOptions} [options] - The feed options.
-     * @returns {QueryIterator}       - An instance of queryIterator to handle reading feed.
-     */
     public readOffers(options?: FeedOptions) {
         return this.queryOffers(undefined, options);
     }
 
-    /**
-     * Lists all offers that satisfy a query.
-     * @memberof DocumentClient
-     * @instance
-     * @param {SqlQuerySpec | string} query - A SQL query.
-     * @param {FeedOptions} [options]       - The feed options.
-     * @returns {QueryIterator}             - An instance of QueryIterator to handle reading feed.
-     */
     public queryOffers(query: string | SqlQuerySpec, options?: FeedOptions) {
         return new QueryIterator(this, query, options, (innerOptions) => {
             return this.queryFeed(
@@ -2732,16 +1913,6 @@ export class DocumentClient extends DocumentClientBase {
     }
 }
 
-/**
- * The callback to execute after the request execution.
- * @callback RequestCallback
- * @param {object} error            -       Will contain error information if an error occurs, undefined otherwise.
- * @param {number} error.code       -       The response code corresponding to the error.
- * @param {string} error.body       -       A string represents the error information.
- * @param {Object} resource         -       An object that represents the requested resource \
- * (Db, collection, document ... etc) if no error happens.
- * @param {object} responseHeaders  -       An object that contain the response headers.
- */
 export interface RequestCallback {
     error?: RequestError;
     resource: any; // TODO: any
@@ -2781,44 +1952,3 @@ export interface Options {
     contentType?: string;
     a_im?: string;
 }
-
-/**
- * The Indexing Policy represents the indexing policy configuration for a collection.
- * @typedef {Object} IndexingPolicy
- * @property {boolean} automatic -         Specifies whether automatic indexing is enabled for a collection.
- * <p>In automatic indexing, documents can be explicitly excluded from indexing using {@link RequestOptions}.
- * In manual indexing, documents can be explicitly included. </p>
- * @property {string} indexingMode -         The indexing mode (consistent or lazy) {@link IndexingMode}.
- * @property {Array} IncludedPaths -         An array of {@link IncludedPath} represents the paths to be \
- * included for indexing.
- * @property {Array} ExcludedPaths -         An array of {@link ExcludedPath} represents the paths to be \
- * excluded from indexing.
- *
- */
-
-/**
- * <p> Included path. <br>
- * </p>
- * @typedef {Object} IncludedPath
- * @property {Array} Indexes                                               -         An array of {@link Indexes}.
- * @property {string} Path                                                 -         Path to be indexed.
- *
- */
-
-/**
- * <p> Index specification. <br>
- * </p>
- * @typedef {Object} Indexes
- * @property {string} Kind                                                  -         The index kind {@link IndexKind}.
- * @property {string} DataType                                              -         The data type {@link DataType}.
- * @property {number} Precision                                             -         The precision.
- *
- */
-
-/**
- * <p> Excluded path. <br>
- * </p>
- * @typedef {Object} ExcludedPath
- * @property {string} Path                                                  -         Path to be indexed.
- *
- */

--- a/src/documents/IndexingPolicy.ts
+++ b/src/documents/IndexingPolicy.ts
@@ -2,9 +2,12 @@ import { IndexingMode } from ".";
 import { DataType, IndexKind } from "./documents";
 
 export interface IndexingPolicy {
+    /** The indexing mode (consistent or lazy) {@link IndexingMode}. */
     indexingMode?: IndexingMode;
     automatic?: boolean;
+    /** An array of {@link IncludedPath} represents the paths to be included for indexing. */
     includedPaths?: IndexedPath[];
+    /** An array of {@link IncludedPath} represents the paths to be excluded for indexing. */
     excludedPaths?: IndexedPath[];
 }
 

--- a/src/test/common/TestData.ts
+++ b/src/test/common/TestData.ts
@@ -1,3 +1,4 @@
+/** @hidden */
 export class TestData {
     public numberOfDocuments: number;
     public field: string;

--- a/src/test/common/TestHelpers.ts
+++ b/src/test/common/TestHelpers.ts
@@ -5,6 +5,7 @@ import {
 } from "../../";
 import { ContainerDefinition, PermissionDefinition, User, UserDefinition } from "../../client";
 
+/** @hidden */
 export class TestHelpers {
     public static async removeAllDatabases(client: CosmosClient) {
         try {


### PR DESCRIPTION
Moves the existing docs from `documentclient.ts`. There is still a lot of doc work to be done, the goal here was just to port current docs.

Notes:
- Marks everything in `documentclient.ts` as hidden
- Removes existing docs from `documentclient.ts`. We may not want to do this, the purpose was to help me keep track of progress.