### PR TITLE
Enable Travis CI

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+script:
+  - npm run build
+  - npm run test


### PR DESCRIPTION
Supersedes https://github.com/Azure/azure-cosmos-js/pull/29. It appears that Travis needs to see the `travis.yml` file on master before builds will start working correctly.