### PR TITLE
WIP Enable noUnusedLocals for typescript compiler

### DIFF
--- a/src/CosmosClient.ts
+++ b/src/CosmosClient.ts
@@ -13,7 +13,7 @@ export class CosmosClient {
     public readonly databases: Databases;
     public readonly offers: Offers;
     public documentClient: DocumentClient; // TODO: This will go away.
-    constructor(private options: CosmosClientOptions) {
+    constructor(options: CosmosClientOptions) {
         this.databases = new Databases(this);
         this.offers = new Offers(this);
 

--- a/src/client/Container/Container.ts
+++ b/src/client/Container/Container.ts
@@ -1,4 +1,4 @@
-import { Constants, UriFactory } from "../../common";
+import { UriFactory } from "../../common";
 import { RequestOptions, Response } from "../../request";
 import { Database } from "../Database";
 import { Items } from "../Item";

--- a/src/client/Container/ContainerDefinition.ts
+++ b/src/client/Container/ContainerDefinition.ts
@@ -1,4 +1,4 @@
-import { IndexingPolicy, PartitionKey, PartitionKeyDefinition } from "../../documents";
+import { IndexingPolicy, PartitionKeyDefinition } from "../../documents";
 
 export interface ContainerDefinition {
     /** The id of the container. */

--- a/src/client/Database/Database.ts
+++ b/src/client/Database/Database.ts
@@ -1,4 +1,4 @@
-import { Constants, UriFactory } from "../../common";
+import { UriFactory } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions, Response } from "../../request";
 import { Containers } from "../Container";

--- a/src/client/Item/Item.ts
+++ b/src/client/Item/Item.ts
@@ -1,4 +1,4 @@
-import { Constants, UriFactory } from "../../common";
+import { UriFactory } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions, Response } from "../../request";
 import { Container } from "../Container";

--- a/src/client/Offer/Offer.ts
+++ b/src/client/Offer/Offer.ts
@@ -1,4 +1,4 @@
-import { Constants, UriFactory } from "../../common";
+import { Constants } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions, Response } from "../../request";
 import { OfferDefinition } from "./OfferDefinition";

--- a/src/client/Permission/Permission.ts
+++ b/src/client/Permission/Permission.ts
@@ -1,4 +1,4 @@
-import { Constants, UriFactory } from "../../common";
+import { UriFactory } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
 import { Response } from "../../request";
 import { RequestOptions } from "../../request/RequestOptions";

--- a/src/client/StoredProcedure/StoredProcedure.ts
+++ b/src/client/StoredProcedure/StoredProcedure.ts
@@ -1,4 +1,4 @@
-import { Constants, UriFactory } from "../../common";
+import { UriFactory } from "../../common";
 import { DocumentClient } from "../../documentclient";
 import { RequestOptions, Response } from "../../request";
 import { Container } from "../Container";

--- a/src/client/Trigger/Trigger.ts
+++ b/src/client/Trigger/Trigger.ts
@@ -1,4 +1,4 @@
-import { Constants, UriFactory } from "../../common";
+import { UriFactory } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions, Response } from "../../request";
 import { Container } from "../Container";

--- a/src/client/User/User.ts
+++ b/src/client/User/User.ts
@@ -1,4 +1,4 @@
-import { Constants, UriFactory } from "../../common";
+import { UriFactory } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions, Response } from "../../request";
 import { Database } from "../Database";

--- a/src/client/UserDefinedFunction/UserDefinedFunction.ts
+++ b/src/client/UserDefinedFunction/UserDefinedFunction.ts
@@ -1,4 +1,4 @@
-import { Constants, UriFactory } from "../../common";
+import { UriFactory } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions, Response } from "../../request";
 import { Container } from "../Container";

--- a/src/documentclient.ts
+++ b/src/documentclient.ts
@@ -1,21 +1,13 @@
-import { resolvePtr } from "dns";
-import { basename } from "path";
 import { Readable } from "stream";
-import * as tunnel from "tunnel";
-import * as url from "url";
-import * as util from "util";
 import { Base, ResponseCallback } from "./base";
-import { Constants, Helper, Platform, StatusCodes, SubStatusCodes } from "./common";
+import { Constants, StatusCodes, SubStatusCodes } from "./common";
 import { DocumentClientBase } from "./DocumentClientBase";
 import {
-    ConnectionPolicy, ConsistencyLevel, DatabaseAccount, Document, PartitionKey, QueryCompatibilityMode,
+    ConnectionPolicy, ConsistencyLevel, Document, PartitionKey, QueryCompatibilityMode,
 } from "./documents";
-import { GlobalEndpointManager } from "./globalEndpointManager";
 import { FetchFunctionCallback, IHeaders, SqlQuerySpec } from "./queryExecutionContext";
 import { QueryIterator } from "./queryIterator";
-import { ErrorResponse, FeedOptions, MediaOptions, RequestHandler, RequestOptions, Response } from "./request";
-import { RetryOptions } from "./retry";
-import { SessionContainer } from "./sessionContainer";
+import { ErrorResponse, FeedOptions, MediaOptions, RequestOptions, Response } from "./request";
 
 export class DocumentClient extends DocumentClientBase {
     constructor(
@@ -454,8 +446,6 @@ export class DocumentClient extends DocumentClientBase {
         const optionsCallbackTuple = this.validateOptionsAndCallback(options, callback);
         options = optionsCallbackTuple.options;
         callback = optionsCallbackTuple.callback;
-
-        const resourceInfo = Base.parseLink(triggerLink);
 
         const isNameBased = Base.isLinkNameBased(triggerLink);
         const path = this.getPathFromLink(triggerLink, "", isNameBased);
@@ -1686,7 +1676,7 @@ export class DocumentClient extends DocumentClientBase {
         }
 
         try {
-            const { result: collection, headers } = await this.readCollection(collectionLink);
+            const { headers } = await this.readCollection(collectionLink);
             return Base.ResponseOrCallback(callback,
                 { result: this.partitionKeyDefinitionCache[collectionLink], headers });
         } catch (err) {

--- a/src/hash/consistentHashRing.ts
+++ b/src/hash/consistentHashRing.ts
@@ -1,4 +1,3 @@
-import { Base } from "../base";
 import { Key, MurmurHash } from "./murmurHash";
 
 export { Key } from "./murmurHash";

--- a/src/hash/hashPartitionResolver.ts
+++ b/src/hash/hashPartitionResolver.ts
@@ -1,6 +1,6 @@
 import { Base } from "../base";
 import { Document, PartitionKey } from "../documents";
-import { PartitionKeyExtractor, PartitionKeyExtractorFunction } from "../range";
+import { PartitionKeyExtractor } from "../range";
 import { ConsistentHashRing } from "./consistentHashRing";
 
 export class HashPartitionResolver {

--- a/src/queryExecutionContext/EndpointComponent/AggregateEndpointComponent.ts
+++ b/src/queryExecutionContext/EndpointComponent/AggregateEndpointComponent.ts
@@ -126,7 +126,7 @@ export class AggregateEndpointComponent implements IEndpointComponent {
      */
     public async current(): Promise<Response<any>> {
         if (this.aggregateValues === undefined) {
-            const {result: resouces, headers} = await this._getAggregateResult();
+            const {headers} = await this._getAggregateResult();
             return {result: this.aggregateValues[this.aggregateValuesIndex], headers};
         } else {
             return {result: this.aggregateValues[this.aggregateValuesIndex], headers: undefined};

--- a/src/queryExecutionContext/defaultQueryExecutionContext.ts
+++ b/src/queryExecutionContext/defaultQueryExecutionContext.ts
@@ -1,9 +1,7 @@
 import { IExecutionContext } from ".";
 import { Constants } from "../common";
-import { DocumentClient } from "../documentclient";
 import { ClientSideMetrics, QueryMetrics } from "../queryMetrics";
 import { Response } from "../request";
-import { SqlParameter, SqlQuerySpec } from "./SqlQuerySpec";
 
 export type FetchFunctionCallback = (options: any) => Promise<Response<any>>;
 
@@ -15,8 +13,6 @@ enum STATES {
 
 export class DefaultQueryExecutionContext implements IExecutionContext {
     private static readonly STATES = STATES;
-    private documentclient: DocumentClient;
-    private query: string | SqlQuerySpec;
     private resources: any; // TODO: any resources
     private currentIndex: number;
     private currentPartitionIndex: number;
@@ -36,12 +32,8 @@ export class DefaultQueryExecutionContext implements IExecutionContext {
      * @ignore
      */
     constructor(
-        documentclient: DocumentClient,
-        query: string | SqlQuerySpec,
         options: any,
         fetchFunctions: FetchFunctionCallback | FetchFunctionCallback[]) { // TODO: any options
-        this.documentclient = documentclient;
-        this.query = query;
         this.resources = [];
         this.currentIndex = 0;
         this.currentPartitionIndex = 0;

--- a/src/queryExecutionContext/headerUtils.ts
+++ b/src/queryExecutionContext/headerUtils.ts
@@ -1,6 +1,4 @@
-﻿import * as assert from "assert";
-import * as util from "util";
-import { Constants } from "../common";
+﻿import { Constants } from "../common";
 import { QueryMetrics } from "../queryMetrics";
 
 export interface IHeaders {

--- a/src/queryExecutionContext/parallelQueryExecutionContext.ts
+++ b/src/queryExecutionContext/parallelQueryExecutionContext.ts
@@ -5,7 +5,6 @@ import {
     PartitionedQueryExecutionContextInfo,
 } from ".";
 import { DocumentClient } from "../documentclient";
-import { PARITIONKEYRANGE } from "../routing";
 
 export class ParallelQueryExecutionContext extends ParallelQueryExecutionContextBase implements IExecutionContext {
     /**
@@ -40,38 +39,5 @@ export class ParallelQueryExecutionContext extends ParallelQueryExecutionContext
         const a = docProd1.getTargetParitionKeyRange()["minInclusive"];
         const b = docProd2.getTargetParitionKeyRange()["minInclusive"];
         return (a === b ? 0 : (a > b ? 1 : -1));
-    }
-
-    private _buildContinuationTokenFrom(documentProducer: DocumentProducer) {
-        // given the document producer constructs the continuation token
-        if (documentProducer.allFetched && documentProducer.peekBufferedItems().length === 0) {
-            return undefined;
-        }
-
-        const min = documentProducer.targetPartitionKeyRange[PARITIONKEYRANGE.MinInclusive];
-        const max = documentProducer.targetPartitionKeyRange[PARITIONKEYRANGE.MaxExclusive];
-        const range = {
-            min,
-            max,
-            id: documentProducer.targetPartitionKeyRange.id,
-        };
-
-        // TODO: static method
-        const withNullDefault = (token: any) => {
-            if (token) {
-                return token;
-            } else if (token === null || token === undefined) {
-                return null;
-            }
-        };
-
-        const documentProducerContinuationToken = documentProducer.peekBufferedItems().length > 0
-            ? documentProducer.previousContinuationToken
-            : documentProducer.continuationToken;
-
-        return {
-            token: withNullDefault(documentProducerContinuationToken),
-            range,
-        };
     }
 }

--- a/src/queryExecutionContext/pipelinedQueryExecutionContext.ts
+++ b/src/queryExecutionContext/pipelinedQueryExecutionContext.ts
@@ -1,4 +1,3 @@
-import * as assert from "assert";
 import {
     HeaderUtils,
     IExecutionContext,

--- a/src/queryExecutionContext/proxyQueryExecutionContext.ts
+++ b/src/queryExecutionContext/proxyQueryExecutionContext.ts
@@ -3,7 +3,6 @@ import {
     DefaultQueryExecutionContext,
     FetchFunctionCallback,
     IExecutionContext,
-    IHeaders,
     PartitionedQueryExecutionContextInfo,
     PipelinedQueryExecutionContext,
     SqlQuerySpec,
@@ -39,7 +38,7 @@ export class ProxyQueryExecutionContext implements IExecutionContext {
         this.options = JSON.parse(JSON.stringify(options || {}));
         this.resourceLink = resourceLink;
         this.queryExecutionContext =
-            new DefaultQueryExecutionContext(this.documentclient, this.query, this.options, this.fetchFunctions);
+            new DefaultQueryExecutionContext(this.options, this.fetchFunctions);
     }
     /**
      * Execute a provided function on the next element in the ProxyQueryExecutionContext.

--- a/src/queryMetrics/clientSideMetrics.ts
+++ b/src/queryMetrics/clientSideMetrics.ts
@@ -1,5 +1,3 @@
-import { QueryMetricsUtils } from "./queryMetricsUtils";
-
 export class ClientSideMetrics {
     constructor(public readonly requestCharge: number) { }
 

--- a/src/queryMetrics/queryMetricsUtils.ts
+++ b/src/queryMetrics/queryMetricsUtils.ts
@@ -1,4 +1,3 @@
-import { isNumber } from "util";
 import { TimeSpan } from "./timeSpan";
 
 export class QueryMetricsUtils {

--- a/src/queryMetrics/timeSpan.ts
+++ b/src/queryMetrics/timeSpan.ts
@@ -19,14 +19,9 @@ const millisPerSecond = 1000;
 const millisPerMinute = millisPerSecond * 60; //     60,000
 const millisPerHour = millisPerMinute * 60;   //  3,600,000
 const millisPerDay = millisPerHour * 24;      // 86,400,000
-
-const maxSeconds = Number.MAX_SAFE_INTEGER / ticksPerSecond;
-const minSeconds = Number.MIN_SAFE_INTEGER / ticksPerSecond;
-
 const maxMilliSeconds = Number.MAX_SAFE_INTEGER / ticksPerMillisecond;
 const minMilliSeconds = Number.MIN_SAFE_INTEGER / ticksPerMillisecond;
 
-const ticksPerTenthSecond = ticksPerMillisecond * 100;
 /**
  * Represents a time interval.
  *

--- a/src/request/request.ts
+++ b/src/request/request.ts
@@ -1,4 +1,4 @@
-import { Agent, ClientRequest, ClientResponse, OutgoingHttpHeaders, ServerResponse } from "http"; // TYPES ONLY
+import { Agent, ClientRequest, ClientResponse, OutgoingHttpHeaders } from "http"; // TYPES ONLY
 import { RequestOptions } from "https"; // TYPES ONLY
 import { Socket } from "net";
 import * as querystring from "querystring";

--- a/src/retry/endpointDiscoveryRetryPolicy.ts
+++ b/src/retry/endpointDiscoveryRetryPolicy.ts
@@ -1,5 +1,4 @@
-﻿import { Constants, StatusCodes } from "../common";
-import { GlobalEndpointManager } from "../globalEndpointManager";
+﻿import { GlobalEndpointManager } from "../globalEndpointManager";
 import { ErrorResponse } from "../request/request";
 
 /**

--- a/src/retry/resourceThrottleRetryPolicy.ts
+++ b/src/retry/resourceThrottleRetryPolicy.ts
@@ -1,5 +1,4 @@
-﻿import { StatusCodes } from "../common";
-import { ErrorResponse } from "../request/request";
+﻿import { ErrorResponse } from "../request/request";
 
 /**
  * This class implements the resource throttle retry policy for requests.

--- a/src/retry/retryUtility.ts
+++ b/src/retry/retryUtility.ts
@@ -1,4 +1,3 @@
-﻿import { WriteStream } from "fs";
 import { RequestOptions } from "https";
 import { Stream } from "stream";
 import * as url from "url";
@@ -6,8 +5,7 @@ import { EndpointDiscoveryRetryPolicy, ResourceThrottleRetryPolicy, SessionReadR
 import { Constants, StatusCodes, SubStatusCodes } from "../common";
 import { ConnectionPolicy } from "../documents";
 import { GlobalEndpointManager } from "../globalEndpointManager";
-import { IHeaders } from "../queryExecutionContext";
-import { ErrorResponse, Response } from "../request";
+import { Response } from "../request";
 import { DefaultRetryPolicy } from "./defaultRetryPolicy";
 
 export interface Body {

--- a/src/retry/sessionReadRetryPolicy.ts
+++ b/src/retry/sessionReadRetryPolicy.ts
@@ -1,6 +1,6 @@
-﻿import * as url from "url";
+import * as url from "url";
 import { Base } from "../base";
-import { Constants, StatusCodes, SubStatusCodes } from "../common";
+import { Constants } from "../common";
 import { GlobalEndpointManager } from "../globalEndpointManager";
 import { ErrorResponse } from "../request/request";
 

--- a/src/routing/CollectionRoutingMapFactory.ts
+++ b/src/routing/CollectionRoutingMapFactory.ts
@@ -25,8 +25,7 @@ export class CollectionRoutingMapFactory {
         const orderedPartitionInfo = sortedRanges.map((r) => r[1]);
 
         if (!this._isCompleteSetOfRange(partitionKeyOrderedRange)) { return undefined; }
-        return new InMemoryCollectionRoutingMap(
-            rangeById, rangeByInfo, partitionKeyOrderedRange, orderedPartitionInfo, collectionUniqueId);
+        return new InMemoryCollectionRoutingMap(partitionKeyOrderedRange, orderedPartitionInfo);
     }
 
     private static _isCompleteSetOfRange(partitionKeyOrderedRange: any) { // TODO: any

--- a/src/routing/inMemoryCollectionRoutingMap.ts
+++ b/src/routing/inMemoryCollectionRoutingMap.ts
@@ -1,17 +1,13 @@
 import * as assert from "assert";
 import * as bs from "binary-search-bounds"; // TODO: missing types
 import { Constants } from "../common";
-import { Range } from "../range";
 import { QueryRange } from "./QueryRange";
 
 export class InMemoryCollectionRoutingMap {
-    private rangeById: Range[];
-    private rangeByInfo: string;
     private orderedPartitionKeyRanges: any[];
     private orderedRanges: QueryRange[];
     // TODO: chrande made this public, even though it is implementation detail for a test
     public orderedPartitionInfo: any;
-    private collectionUniqueId: any;
 
     /**
      * Represents a InMemoryCollectionRoutingMap Object,
@@ -19,13 +15,8 @@ export class InMemoryCollectionRoutingMap {
      * convenience methods for working with set of ranges.
      */
     constructor(
-        rangeById: Range[],
-        rangeByInfo: string,
         orderedPartitionKeyRanges: any[],
-        orderedPartitionInfo: any,
-        collectionUniqueId: string) {
-        this.rangeById = rangeById;
-        this.rangeByInfo = rangeByInfo;
+        orderedPartitionInfo: any) {
         this.orderedPartitionKeyRanges = orderedPartitionKeyRanges;
         this.orderedRanges = orderedPartitionKeyRanges.map(
             (pkr) => {
@@ -34,7 +25,6 @@ export class InMemoryCollectionRoutingMap {
                     pkr[Constants.PartitionKeyRange.MaxExclusive], true, false);
             });
         this.orderedPartitionInfo = orderedPartitionInfo;
-        this.collectionUniqueId = collectionUniqueId;
     }
     public getOrderedParitionKeyRanges() {
         return this.orderedPartitionKeyRanges;

--- a/src/sessionContainer.ts
+++ b/src/sessionContainer.ts
@@ -140,7 +140,6 @@ export class SessionContainer {
             if (newTokenParts.length === 2) {
                 const range = newTokenParts[0];
                 const newLSN = BigInt(newTokenParts[1]);
-                const success = false;
 
                 const oldLSN = BigInt(oldTokens[range]);
                 if (!oldLSN || oldLSN.lesser(newLSN)) {

--- a/src/test/common/TestHelpers.ts
+++ b/src/test/common/TestHelpers.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import {
     Container, CosmosClient,
-    Database, DatabaseDefinition, Item, RequestOptions, Response,
+    Database, DatabaseDefinition, RequestOptions, Response,
 } from "../../";
 import { ContainerDefinition, PermissionDefinition, User, UserDefinition } from "../../client";
 
@@ -16,7 +16,6 @@ export class TestHelpers {
                 return;
             }
 
-            const count = 0;
             await Promise.all(databases.map<Promise<Response<DatabaseDefinition>>>(
                 async (database: DatabaseDefinition) => client.databases.get(database.id).delete()));
         } catch (err) {
@@ -103,7 +102,7 @@ export class TestHelpers {
                     ? { partitionKey: document[partitionKeyPropertyName] }
                     : { partitionKey: {} };
 
-                const { result } = await container.items.get(document.id).delete(options);
+                await container.items.get(document.id).delete(options);
             } catch (err) {
                 throw err;
             }

--- a/src/test/functional/HashPartitionResolver.spec.ts
+++ b/src/test/functional/HashPartitionResolver.spec.ts
@@ -1,7 +1,5 @@
-import * as assert from "assert";
-import * as Stream from "stream";
 import {
-    CosmosClient, HashPartitionResolver,
+    CosmosClient,
 } from "../../";
 import testConfig from "./../common/_testConfig";
 import { TestHelpers } from "./../common/TestHelpers";

--- a/src/test/functional/authorization.spec.ts
+++ b/src/test/functional/authorization.spec.ts
@@ -87,7 +87,7 @@ describe("NodeJS CRUD Tests", function () {
         const authorizationCRUDTest = async function (isUpsertTest: boolean) {
             try {
                 const badclient = new CosmosClient({ endpoint, auth: undefined });
-                const { result: databases } = await badclient.databases.readAll().toArray();
+                await badclient.databases.readAll().toArray();
                 assert.fail("Must fail");
             } catch (err) {
                 assert(err !== undefined, "error should not be undefined");

--- a/src/test/functional/container.spec.ts
+++ b/src/test/functional/container.spec.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import {
     Constants, CosmosClient, DocumentBase,
 } from "../../";
-import { Container, ContainerDefinition, Database } from "../../client";
+import { ContainerDefinition, Database } from "../../client";
 import { DataType, Index, IndexedPath, IndexingMode, IndexingPolicy, IndexKind } from "../../documents";
 import testConfig from "./../common/_testConfig";
 import { TestHelpers } from "./../common/TestHelpers";
@@ -387,7 +387,7 @@ describe("NodeJS CRUD Tests", function () {
     describe("Validate response headers", function () {
         const createThenReadcontainer = async function (database: Database, body: ContainerDefinition) {
             try {
-                const { result: createdcontainer, headers } = await database.containers.create(body);
+                const { result: createdcontainer } = await database.containers.create(body);
                 const response = await database.containers.get(createdcontainer.id).read();
                 return response;
             } catch (err) {

--- a/src/test/functional/database.spec.ts
+++ b/src/test/functional/database.spec.ts
@@ -78,7 +78,7 @@ describe("NodeJS CRUD Tests", function () {
         it("nativeApi Should fail on ends with a space", async function () {
             // Id shoudn't end with a space.
             try {
-                const { result: db } = await client.databases.create({ id: "id_ends_with_space " });
+                await client.databases.create({ id: "id_ends_with_space " });
                 assert.fail("Must throw if id ends with a space");
             } catch (err) {
                 assert.equal("Id ends with a space.", err.message);
@@ -88,7 +88,7 @@ describe("NodeJS CRUD Tests", function () {
         it("nativeAPI Should fail on contains '/'", async function() {
             // Id shoudn't contain "/".
             try {
-                const { result: db } = await client.databases.create({ id: "id_with_illegal/_char" });
+                await client.databases.create({ id: "id_with_illegal/_char" });
                 assert.fail("Must throw if id has illegal characters");
             } catch (err) {
                 assert.equal("Id contains illegal chars.", err.message);
@@ -98,7 +98,7 @@ describe("NodeJS CRUD Tests", function () {
         it("nativeAPI Should fail on contains '\\'", async function() {
             // Id shoudn't contain "\\".
             try {
-                const { result: db } = await client.databases.create({ id: "id_with_illegal\\_char" });
+                await client.databases.create({ id: "id_with_illegal\\_char" });
                 assert.fail("Must throw if id contains illegal characters");
             } catch (err) {
                 assert.equal("Id contains illegal chars.", err.message);
@@ -108,7 +108,7 @@ describe("NodeJS CRUD Tests", function () {
         it("nativeAPI Should fail on contains '?'", async function() {
             // Id shoudn't contain "?".
             try {
-                const { result: db } = await client.databases.create({ id: "id_with_illegal?_?char" });
+                await client.databases.create({ id: "id_with_illegal?_?char" });
                 assert.fail("Must throw if id contains illegal characters");
             } catch (err) {
                 assert.equal("Id contains illegal chars.", err.message);
@@ -119,7 +119,7 @@ describe("NodeJS CRUD Tests", function () {
 
             // Id shoudn't contain "#".
             try {
-                const { result: db } = await client.databases.create({ id: "id_with_illegal#_char" });
+                await client.databases.create({ id: "id_with_illegal#_char" });
                 assert.fail("Must throw if id contains illegal characters");
             } catch (err) {
                 assert.equal("Id contains illegal chars.", err.message);

--- a/src/test/functional/item.spec.ts
+++ b/src/test/functional/item.spec.ts
@@ -87,14 +87,14 @@ describe("NodeJS CRUD Tests", function () {
                 assert.equal(replacedDocument.foo, "not bar", "property should have changed");
                 assert.equal(document.id, replacedDocument.id, "document id should stay the same");
                 // read document
-                const { result: document2 } = await container.items.get(replacedDocument.id).read();
+                await container.items.get(replacedDocument.id).read();
                 assert.equal(replacedDocument.id, document.id);
                 // delete document
-                const { result: res } = await container.items.get(replacedDocument.id).delete();
+                await container.items.get(replacedDocument.id).delete();
 
                 // read documents after deletion
                 try {
-                    const { result: document3 } = await container.items.get(replacedDocument.id).read();
+                    await container.items.get(replacedDocument.id).read();
                     assert.fail("must throw if document doesn't exist");
                 } catch (err) {
                     const notFoundErrorCode = 404;
@@ -159,7 +159,7 @@ describe("NodeJS CRUD Tests", function () {
                     query: "SELECT * FROM Root",
                 };
                 try {
-                    const { result: badUpdate } = await container.items.query(
+                    await container.items.query(
                         querySpec, { enableScanInQuery: true }).toArray();
                     assert.fail("Must fail");
                 } catch (err) {

--- a/src/test/functional/permission.spec.ts
+++ b/src/test/functional/permission.spec.ts
@@ -81,7 +81,7 @@ describe("NodeJS CRUD Tests", function () {
                 assert.equal(permissionAfterReplace.id, permissionDef.id);
 
                 // delete permission
-                const { result: res } = await permission.delete();
+                await permission.delete();
 
                 // read permission after deletion
                 try {
@@ -172,7 +172,7 @@ describe("NodeJS CRUD Tests", function () {
                 assert.equal(permissionAfterReplace.id, replacedPermission2.id);
 
                 // delete permission
-                const { result: res } = await permission.delete();
+                await permission.delete();
 
                 // read permission after deletion
                 try {

--- a/src/test/functional/sproc.spec.ts
+++ b/src/test/functional/sproc.spec.ts
@@ -1,9 +1,7 @@
 import * as assert from "assert";
-import * as Stream from "stream";
 import {
-    AzureDocuments, Base, Constants, CosmosClient,
-    DocumentBase, HashPartitionResolver, Range,
-    RangePartitionResolver, Response, RetryOptions,
+    Constants, CosmosClient,
+    DocumentBase,
 } from "../../";
 import { Container, StoredProcedureDefinition } from "../../client";
 import testConfig from "./../common/_testConfig";
@@ -64,6 +62,7 @@ describe("NodeJS CRUD Tests", function () {
             assert(queriedSprocs.length > 0, "number of sprocs for the query should be > 0");
 
             // replace sproc
+            // @ts-ignore
             sproc.body = function () { const x = 20; };
             const { result: replacedSproc } = await container.storedProcedures.get(sproc.id).replace(sproc);
 
@@ -97,7 +96,8 @@ describe("NodeJS CRUD Tests", function () {
             const sprocDefinition: StoredProcedureDefinition = {
                 id: "sample sproc",
                 // tslint:disable-next-line:object-literal-shorthand
-                body: function() { const x = 10; },
+                // @ts-ignore
+                body: function() { const x = 10; }, // tslint:disable-line:object-literal-shorthand
             };
 
             const { result: sproc } = await container.storedProcedures.upsert(sprocDefinition);
@@ -117,6 +117,7 @@ describe("NodeJS CRUD Tests", function () {
             assert(queriedSprocs.length > 0, "number of sprocs for the query should be > 0");
 
             // replace sproc
+            // @ts-ignore
             sproc.body = function () { const x = 20; };
             const { result: replacedSproc } = await container.storedProcedures.upsert(sproc);
 
@@ -300,7 +301,7 @@ describe("NodeJS CRUD Tests", function () {
             { id: "document6", key: "A", prop: 1 },
         ];
 
-        const returnedDocuments = await TestHelpers.bulkInsertItems(container, documents);
+        await TestHelpers.bulkInsertItems(container, documents);
         const { result: sproc } = await container.storedProcedures.create(querySproc);
         const { result: result } = await container.storedProcedures.get(sproc.id).execute([], { partitionKey: null });
         assert(result !== undefined);

--- a/src/test/functional/trigger.spec.ts
+++ b/src/test/functional/trigger.spec.ts
@@ -89,6 +89,7 @@ describe("NodeJS CRUD Tests", function () {
             assert(results.length > 0, "number of results for the query should be > 0");
 
             // replace trigger
+            // @ts-ignore Typescript warns on unused const decleration
             trigger.body = function () { const x = 20; };
             const { result: replacedTrigger } = await container.triggers.get(trigger.id).replace(trigger);
 
@@ -153,6 +154,7 @@ describe("NodeJS CRUD Tests", function () {
             assert(results.length > 0, "number of results for the query should be > 0");
 
             // replace trigger
+            // @ts-ignore Typescript warns on unused const decleration
             trigger.body = function () { const x = 20; };
             const { result: replacedTrigger } = await container.triggers.upsert(trigger);
 
@@ -246,7 +248,7 @@ describe("NodeJS CRUD Tests", function () {
             assert.equal(document3.id, "doc3t3");
             const { result: document4 } = await container.items.create({ id: "testing post trigger" }, { postTriggerInclude: "response1", preTriggerInclude: "t1" });
             assert.equal(document4.id, "TESTING POST TRIGGERt1");
-            const { result: document5, headers } = await container.items.create({ id: "responseheaders" }, { preTriggerInclude: "t1" });
+            const { result: document5 } = await container.items.create({ id: "responseheaders" }, { preTriggerInclude: "t1" });
             assert.equal(document5.id, "RESPONSEHEADERSt1");
             try {
                 await container.items.create({ id: "Docoptype" }, { postTriggerInclude: "triggerOpType" });
@@ -269,7 +271,7 @@ describe("NodeJS CRUD Tests", function () {
             assert.equal(document3.id, "doc3t3");
             const { result: document4 } = await container.items.upsert({ id: "testing post trigger" }, { postTriggerInclude: "response1", preTriggerInclude: "t1" });
             assert.equal(document4.id, "TESTING POST TRIGGERt1");
-            const { result: document5, headers } = await container.items.upsert({ id: "responseheaders" }, { preTriggerInclude: "t1" });
+            const { result: document5 } = await container.items.upsert({ id: "responseheaders" }, { preTriggerInclude: "t1" });
             assert.equal(document5.id, "RESPONSEHEADERSt1");
             try {
                 await container.items.upsert({ id: "Docoptype" }, { postTriggerInclude: "triggerOpType" });

--- a/src/test/functional/ttl.spec.ts
+++ b/src/test/functional/ttl.spec.ts
@@ -1,5 +1,4 @@
 import * as assert from "assert";
-import * as Stream from "stream";
 import {
     CosmosClient,
 } from "../../";

--- a/src/test/functional/udf.spec.ts
+++ b/src/test/functional/udf.spec.ts
@@ -114,17 +114,13 @@ describe("NodeJS CRUD Tests", function() {
             assert.equal(replacedUdf.id, udfAfterReplace.id);
 
             // delete udf
-            const {
-                result: res,
-            } = await container.userDefinedFunctions
+            await container.userDefinedFunctions
                 .get(replacedUdf.id)
                 .delete();
 
             // read udfs after deletion
             try {
-                const {
-                    result: badudf,
-                } = await container.userDefinedFunctions
+                await container.userDefinedFunctions
                     .get(replacedUdf.id)
                     .read();
                 assert.fail("Must fail to read after delete");
@@ -204,17 +200,13 @@ describe("NodeJS CRUD Tests", function() {
             assert.equal(replacedUdf.id, udfAfterReplace.id);
 
             // delete udf
-            const {
-                result: res,
-            } = await container.userDefinedFunctions
+            await container.userDefinedFunctions
                 .get(replacedUdf.id)
                 .delete();
 
             // read udfs after deletion
             try {
-                const {
-                    result: badudf,
-                } = await container.userDefinedFunctions
+                await container.userDefinedFunctions
                     .get(replacedUdf.id)
                     .read();
                 assert.fail("Must fail to read after delete");

--- a/src/test/functional/user.spec.ts
+++ b/src/test/functional/user.spec.ts
@@ -71,7 +71,7 @@ describe("NodeJS CRUD Tests", function () {
             assert.equal(replacedUser.id, userAfterReplace.id);
 
             // delete user
-            const { result: res } = await user.delete();
+            await user.delete();
 
             // read user after deletion
             try {

--- a/src/test/integration/aggregateQuery.spec.ts
+++ b/src/test/integration/aggregateQuery.spec.ts
@@ -1,7 +1,7 @@
 ﻿import * as assert from "assert";
 import * as util from "util";
 import { QueryIterator } from "../../";
-import { Container, ContainerDefinition, Database } from "../../client";
+import { Container, ContainerDefinition } from "../../client";
 import { CosmosClient } from "../../CosmosClient";
 import { DataType, IndexKind, PartitionKind } from "../../documents";
 import { SqlQuerySpec } from "../../queryExecutionContext";
@@ -20,7 +20,6 @@ describe.skip("NodeJS Aggregate Query Tests", async function () {
     const uniquePartitionKey = "uniquePartitionKey";
     const testdata = new TestData(partitionKey, uniquePartitionKey);
     const documentDefinitions = testdata.docs;
-    let db: Database;
     let container: Container;
 
     const containerDefinition: ContainerDefinition = {
@@ -50,8 +49,6 @@ describe.skip("NodeJS Aggregate Query Tests", async function () {
         },
     };
 
-    const containerOptions = { offerThroughput: 10100 };
-
     describe("Validate Aggregate Document Query", function () {
 
         // - removes all the databases,
@@ -62,7 +59,6 @@ describe.skip("NodeJS Aggregate Query Tests", async function () {
             await TestHelpers.removeAllDatabases(client);
             container = await TestHelpers.getTestContainer(
                 client, "Validate Aggregate Document Query", containerDefinition);
-            db = container.database;
             await TestHelpers.bulkInsertItems(container, documentDefinitions);
         });
 
@@ -75,28 +71,6 @@ describe.skip("NodeJS Aggregate Query Tests", async function () {
                 const { result: results } = await queryIterator.toArray();
                 assert.equal(results.length, expectedResults.length, "invalid number of results");
                 assert.equal(queryIterator.hasMoreResults(), false, "hasMoreResults: no more results is left");
-            } catch (err) {
-                throw err;
-            }
-        };
-
-        const validateNextItem = async function (queryIterator: QueryIterator<any>, expectedResults: any) {
-            let results: any = [];
-
-            try {
-                while (results.length < expectedResults.length) {
-                    const { result: item } = await queryIterator.nextItem();
-                    if (item === undefined) {
-                        assert(!queryIterator.hasMoreResults(), "hasMoreResults must signal results exhausted");
-                        validateResult(results, expectedResults);
-                        return;
-                    }
-                    results = results.concat(item);
-
-                    if (results.length < expectedResults.length) {
-                        assert(queryIterator.hasMoreResults(), "hasMoreResults must indicate more results");
-                    }
-                }
             } catch (err) {
                 throw err;
             }

--- a/src/test/integration/authorization.spec.ts
+++ b/src/test/integration/authorization.spec.ts
@@ -1,5 +1,5 @@
-﻿import * as assert from "assert";
-import { Base, Container, CosmosClient, DocumentBase, UriFactory } from "../../";
+import * as assert from "assert";
+import { Container, CosmosClient, DocumentBase } from "../../";
 import { Database } from "../../client";
 import testConfig from "./../common/_testConfig";
 import { TestHelpers } from "./../common/TestHelpers";

--- a/src/test/integration/crossPartition.spec.ts
+++ b/src/test/integration/crossPartition.spec.ts
@@ -108,30 +108,6 @@ describe("Cross Partition", function () {
             }
         };
 
-        const validateNextItem = async function (
-            queryIterator: QueryIterator<any>, expectedOrderIds: string[]) {
-
-            ////////////////////////////////
-            // validate nextItem()
-            ////////////////////////////////
-            const results: any[] = [];
-            try {
-                while (results.length < expectedOrderIds.length) {
-                    assert(queryIterator.hasMoreResults(), "hasMoreResults must indicate more results");
-                    const { result: item } = await queryIterator.nextItem();
-                    if (item === undefined) {
-                        break;
-                    }
-                    results.push(item);
-                }
-
-                assert(!queryIterator.hasMoreResults(), "hasMoreResults must signal results exhausted");
-                validateResults(results, expectedOrderIds);
-            } catch (err) {
-                throw err;
-            }
-        };
-
         const validateNextItemAndCurrentAndHasMoreResults =
             async function (queryIterator: QueryIterator<any>, expectedOrderIds: string[]) {
                 // curent and nextItem recursively invoke each other till queryIterator is exhausted
@@ -301,10 +277,6 @@ describe("Cross Partition", function () {
             const query = "SELECT * FROM root r";
             const options = { enableCrossPartitionQuery: true, maxItemCount: 2, maxDegreeOfParallelism: 0 };
 
-            // prepare expected results
-            const getOrderByKey = function (r: any) {
-                return r["spam"];
-            };
             const expectedOrderedIds = [1, 10, 18, 2, 3, 13, 14, 16, 17, 0, 11, 12, 5, 9, 19, 4, 6, 7, 8, 15];
 
             // validates the results size and order
@@ -319,10 +291,6 @@ describe("Cross Partition", function () {
                 populateQueryMetrics: true,
             };
 
-            // prepare expected results
-            const getOrderByKey = function (r: any) {
-                return r["spam"];
-            };
             const expectedOrderedIds = [1, 10, 18, 2, 3, 13, 14, 16, 17, 0, 11, 12, 5, 9, 19, 4, 6, 7, 8, 15];
 
             // validates the results size and order
@@ -334,10 +302,6 @@ describe("Cross Partition", function () {
             const query = "SELECT * FROM root r";
             const options = { enableCrossPartitionQuery: true, maxItemCount: 2, maxDegreeOfParallelism: 1 };
 
-            // prepare expected results
-            const getOrderByKey = function (r: any) {
-                return r["spam"];
-            };
             const expectedOrderedIds = [1, 10, 18, 2, 3, 13, 14, 16, 17, 0, 11, 12, 5, 9, 19, 4, 6, 7, 8, 15];
 
             // validates the results size and order
@@ -349,10 +313,6 @@ describe("Cross Partition", function () {
             const query = "SELECT * FROM root r";
             const options = { enableCrossPartitionQuery: true, maxItemCount: 2, maxDegreeOfParallelism: 3 };
 
-            // prepare expected results
-            const getOrderByKey = function (r: any) {
-                return r["spam"];
-            };
             const expectedOrderedIds = [1, 10, 18, 2, 3, 13, 14, 16, 17, 0, 11, 12, 5, 9, 19, 4, 6, 7, 8, 15];
 
             // validates the results size and order
@@ -835,29 +795,30 @@ describe("Cross Partition", function () {
             }
         });
 
-        it("Validate Failure", async function () {
-            // simple order by query in string format
-            const query = "SELECT * FROM root r order by r.spam";
+        // TODO after enabling no-unused compiler checks it appears this test may do nothing.
+        // it("Validate Failure", async function () {
+        //     // simple order by query in string format
+        //     const query = "SELECT * FROM root r order by r.spam";
 
-            const options = { enableCrossPartitionQuery: true, maxItemCount: 2 };
+        //     const options = { enableCrossPartitionQuery: true, maxItemCount: 2 };
 
-            // prepare expected results
-            const getOrderByKey = function (r: any) {
-                return r["spam"];
-            };
-            const expectedOrderedIds = (_.sortBy(documentDefinitions, getOrderByKey).map(function (r) {
-                return r["id"];
-            }));
+        //     // prepare expected results
+        //     const getOrderByKey = function (r: any) {
+        //         return r["spam"];
+        //     };
+        //     const expectedOrderedIds = (_.sortBy(documentDefinitions, getOrderByKey).map(function (r) {
+        //         return r["id"];
+        //     }));
 
-            const queryIterator = container.items.query(query, options);
+        //     const queryIterator = container.items.query(query, options);
 
-            let firstTime = true;
+        //     let firstTime = true;
 
-            const { result } = await queryIterator.current();
+        //     const { result } = await queryIterator.current();
 
-            if (firstTime) {
-                firstTime = false;
-            }
-        });
+        //     if (firstTime) {
+        //         firstTime = false;
+        //     }
+        // });
     });
 });

--- a/src/test/integration/incrementalFeed.spec.ts
+++ b/src/test/integration/incrementalFeed.spec.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { CosmosClient, Database, FeedOptions } from "../../";
+import { CosmosClient, FeedOptions } from "../../";
 import { Container } from "../../client";
 import testConfig from "./../common/_testConfig";
 import { TestHelpers } from "./../common/TestHelpers";

--- a/src/test/integration/query.spec.ts
+++ b/src/test/integration/query.spec.ts
@@ -1,5 +1,5 @@
-﻿import * as assert from "assert";
-import { Constants, CosmosClient, FeedOptions, UriFactory } from "../../";
+import * as assert from "assert";
+import { Constants, CosmosClient, FeedOptions } from "../../";
 import { PartitionKind } from "../../documents";
 import testConfig from "./../common/_testConfig";
 import { TestHelpers } from "./../common/TestHelpers";
@@ -60,7 +60,6 @@ describe("Test Query Metrics On Single Partition Collection", function () {
             const createdContainer = database.containers.get(createdCollectionDef.id);
 
             await createdContainer.items.create(document);
-            const collectionLink = "/dbs/" + databaseId + "/colls/" + collectionId + "/";
             const query = "SELECT * from " + collectionId;
             const queryOptions: FeedOptions = { populateQueryMetrics: true };
             const queryIterator = createdContainer.items.query(query, queryOptions);

--- a/src/test/integration/queryMetrics.spec.ts
+++ b/src/test/integration/queryMetrics.spec.ts
@@ -1,5 +1,4 @@
 import * as assert from "assert";
-import { Constants } from "../../common";
 import {
     ClientSideMetrics,
     QueryMetrics,

--- a/src/test/integration/retry.spec.ts
+++ b/src/test/integration/retry.spec.ts
@@ -1,24 +1,24 @@
-import * as assert from "assert";
-import { AzureDocuments, Constants, CosmosClient, RetryOptions } from "../..";
-import * as request from "../../request";
-import testConfig from "../common/_testConfig";
+// import * as assert from "assert";
+// import { AzureDocuments } from "../..";
+// import * as request from "../../request";
+// import testConfig from "../common/_testConfig";
 
-const endpoint = testConfig.host;
-const masterKey = testConfig.masterKey;
+// const endpoint = testConfig.host;
+// const masterKey = testConfig.masterKey;
 
 describe("retry policy tests", function () {
     this.timeout(300000);
-    const collectionDefinition = {
-        id: "sample collection",
-    };
+    // const collectionDefinition = {
+    //     id: "sample collection",
+    // };
 
-    const documentDefinition = {
-        id: "doc",
-        name: "sample document",
-        key: "value",
-    };
+    // const documentDefinition = {
+    //     id: "doc",
+    //     name: "sample document",
+    //     key: "value",
+    // };
 
-    const connectionPolicy = new AzureDocuments.ConnectionPolicy();
+    // const connectionPolicy = new AzureDocuments.ConnectionPolicy();
 
     // mocked database account to return the WritableLocations and ReadableLocations
     // set with the default endpoint
@@ -27,7 +27,7 @@ describe("retry policy tests", function () {
     //     callback(undefined, databaseAccount);
     // };
 
-    const retryAfterInMilliseconds = 1000;
+    // const retryAfterInMilliseconds = 1000;
     // // mocked request object stub that calls the callback with 429 throttling error
     // const mockCreateRequestObjectStub = function (connectionPolicy, requestOptions, callback) {
     //     callback({ code: 429, body: "Request rate is too large",

--- a/src/test/integration/session.spec.ts
+++ b/src/test/integration/session.spec.ts
@@ -85,7 +85,7 @@ describe("Session Token", function () {
         assert.notEqual(tokens[index2], undefined);
         let secondPartitionLSN = tokens[index2];
 
-        const { result: document12 } = await container.items.get(document1.id, "1").read();
+        await container.items.get(document1.id, "1").read();
         assert.equal(getSpy.lastCall.args[2][Constants.HttpHeaders.SessionToken],
             client.documentClient.sessionContainer.getCombinedSessionToken(tokens));
         tokens = getToken(client.documentClient.sessionContainer.collectionResourceIdToSessionTokens);
@@ -101,7 +101,7 @@ describe("Session Token", function () {
         assert.equal(tokens[index2], secondPartitionLSN);
         firstPartitionLSN = tokens[index1];
 
-        const { result: document22 } = await container.items.get(document2.id, "2").delete();
+        await container.items.get(document2.id, "2").delete();
         assert.equal(deleteSpy.lastCall.args[2][Constants.HttpHeaders.SessionToken],
             client.documentClient.sessionContainer.getCombinedSessionToken(tokens));
         tokens = getToken(client.documentClient.sessionContainer.collectionResourceIdToSessionTokens);
@@ -109,9 +109,8 @@ describe("Session Token", function () {
         assert.equal(tokens[index2], (Number(secondPartitionLSN) + 1).toString());
         secondPartitionLSN = tokens[index2];
 
-        const { result: document14 } =
-            await container.items.get(document13.id)
-                .replace({ id: "1", operation: "replace" }, { partitionKey: "1" });
+        await container.items.get(document13.id)
+            .replace({ id: "1", operation: "replace" }, { partitionKey: "1" });
         assert.equal(putSpy.lastCall.args[3][Constants.HttpHeaders.SessionToken],
             client.documentClient.sessionContainer.getCombinedSessionToken(tokens));
         tokens = getToken(client.documentClient.sessionContainer.collectionResourceIdToSessionTokens);
@@ -123,7 +122,7 @@ describe("Session Token", function () {
         const queryOptions = { partitionKey: "1" };
         const queryIterator = container.items.query(query, queryOptions);
 
-        const { result } = await queryIterator.toArray();
+        await queryIterator.toArray();
         assert.equal(postSpy.lastCall.args[3][Constants.HttpHeaders.SessionToken],
             client.documentClient.sessionContainer.getCombinedSessionToken(tokens));
         tokens = getToken(client.documentClient.sessionContainer.collectionResourceIdToSessionTokens);
@@ -192,11 +191,10 @@ describe("Session Token", function () {
             .containers.get(containerDefinition.id)
             .delete();
 
-        const { result: createdCollection2 } =
-            await client2.databases.get(databaseDef.id)
+        await client2.databases.get(databaseDef.id)
                 .containers.create(containerDefinition, containerOptions);
 
-        const { result: collection2 } = await client2.databases.get(databaseDef.id)
+        await client2.databases.get(databaseDef.id)
             .containers.get(containerDefinition.id)
             .read();
         assert.equal(client.documentClient.getSessionToken(container.url), ""); // TODO: _self

--- a/src/test/unit/base.spec.ts
+++ b/src/test/unit/base.spec.ts
@@ -1,6 +1,4 @@
 ﻿import * as assert from "assert";
-import * as fs from "fs";
-import * as path from "path";
 import { Base } from "../../";
 import content from "./../common/BaselineTest.PathParser";
 

--- a/src/test/unit/consistentHashRing.spec.ts
+++ b/src/test/unit/consistentHashRing.spec.ts
@@ -11,7 +11,7 @@ describe("ConsistentHashRing", function () {
         it("invalid nodes throws", function () {
             assert.throws(
                 function () {
-                    const ring = new ConsistentHashRing(undefined);
+                    return new ConsistentHashRing(undefined);
                 },
                 /Invalid argument: 'nodes' has to be an array./,
             );

--- a/src/test/unit/hashPartitionResolver.spec.ts
+++ b/src/test/unit/hashPartitionResolver.spec.ts
@@ -1,13 +1,12 @@
 ﻿import * as assert from "assert";
 import { HashPartitionResolver } from "../../hash";
-import { PartitionKeyExtractor } from "../../range";
 
 describe("HashPartitionResolver", function () {
     describe("new()", function () {
         it(" does not throw", function () {
             assert.doesNotThrow(
                 function () {
-                    const resolver = new HashPartitionResolver("foo", ["dbs/foo/colls/A"]);
+                    return new HashPartitionResolver("foo", ["dbs/foo/colls/A"]);
                 },
             );
         });
@@ -15,7 +14,7 @@ describe("HashPartitionResolver", function () {
         it("invalid partitionKeyResolver", function () {
             assert.throws(
                 function () {
-                    const resolver = new HashPartitionResolver(undefined, undefined);
+                    return new HashPartitionResolver(undefined, undefined);
                 },
                 /partitionKeyExtractor cannot be null or undefined/,
             );
@@ -24,7 +23,7 @@ describe("HashPartitionResolver", function () {
         it("invalid collectionLinks", function () {
             assert.throws(
                 function () {
-                    const resolver = new HashPartitionResolver("foo", undefined);
+                    return new HashPartitionResolver("foo", undefined);
                 },
                 /collectionLinks must be an array./,
             );

--- a/src/test/unit/inMemoryCollectionRoutingMap.spec.ts
+++ b/src/test/unit/inMemoryCollectionRoutingMap.spec.ts
@@ -1,6 +1,6 @@
 ﻿import * as assert from "assert";
 import * as _ from "underscore";
-import { CollectionRoutingMapFactory, InMemoryCollectionRoutingMap, QueryRange } from "../../routing";
+import { CollectionRoutingMapFactory, QueryRange } from "../../routing";
 
 describe("InMemoryCollectionRoutingMap Tests", function () {
 
@@ -154,9 +154,8 @@ describe("InMemoryCollectionRoutingMap Tests", function () {
                         [{ id: "1", minInclusive: "0000000020", maxExclusive: "0000000030" }, 2],
                         [{ id: "2", minInclusive: "0000000025", maxExclusive: "0000000035" }, 2],
                     ];
-                const collectionUniqueId = "";
                 try {
-                    const collectionRoutingMap = CollectionRoutingMapFactory
+                    CollectionRoutingMapFactory
                         .createCompleteRoutingMap(partitionRangeWithInfo, "sample collection id");
                     assert.fail("must throw exception");
                 } catch (e) {

--- a/src/test/unit/range.spec.ts
+++ b/src/test/unit/range.spec.ts
@@ -6,7 +6,7 @@ describe("Range Tests", function () {
         const invalidOptionsTest = function (options: any, expectedError: any) {
             assert.throws(
                 function () {
-                    const r = new Range(options);
+                    return new Range(options);
                 },
                 expectedError);
         };
@@ -17,11 +17,6 @@ describe("Range Tests", function () {
 
         const optionsIsNotAnObjectTest = function (options: any) {
             invalidOptionsTest(options, /Invalid argument: 'options' is not an object/);
-        };
-
-        const invalidRangeTest = function (options: any) {
-            invalidOptionsTest(options,
-                /Invalid argument: 'options.low' must be less than or equal than 'options.high'/);
         };
 
         it("options - undefined (ommited argument)", function () {

--- a/src/test/unit/rangePartitionResolver.spec.ts
+++ b/src/test/unit/rangePartitionResolver.spec.ts
@@ -10,21 +10,21 @@ describe("RangePartitionResolver", function () {
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver(undefined, undefined);
+                    return new RangePartitionResolver(undefined, undefined);
                 },
                 expetcedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver(undefined, undefined);
+                    return new RangePartitionResolver(undefined, undefined);
                 },
                 expetcedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver(null, undefined);
+                    return new RangePartitionResolver(null, undefined);
                 },
                 expetcedError,
             );
@@ -35,35 +35,35 @@ describe("RangePartitionResolver", function () {
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver(0 as any, undefined);
+                    return new RangePartitionResolver(0 as any, undefined);
                 },
                 expetcedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver(true as any, undefined);
+                    return new RangePartitionResolver(true as any, undefined);
                 },
                 expetcedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver(NaN as any, undefined);
+                    return new RangePartitionResolver(NaN as any, undefined);
                 },
                 expetcedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver([] as any, undefined);
+                    return new RangePartitionResolver([] as any, undefined);
                 },
                 expetcedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver({} as any, undefined);
+                    return new RangePartitionResolver({} as any, undefined);
                 },
                 expetcedError,
             );
@@ -74,21 +74,21 @@ describe("RangePartitionResolver", function () {
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver("", undefined);
+                    return new RangePartitionResolver("", undefined);
                 },
                 expectedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver(function () { /* no op */ } as any, undefined);
+                    return new RangePartitionResolver(function () { /* no op */ } as any, undefined);
                 },
                 expectedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver("", null);
+                    return new RangePartitionResolver("", null);
                 },
                 expectedError,
             );
@@ -99,40 +99,38 @@ describe("RangePartitionResolver", function () {
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver("", 0 as any);
+                    return new RangePartitionResolver("", 0 as any);
                 },
                 expectedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver("", "" as any);
+                    return new RangePartitionResolver("", "" as any);
                 },
                 expectedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver("", true as any);
+                    return new RangePartitionResolver("", true as any);
                 },
                 expectedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver("", NaN as any);
+                    return new RangePartitionResolver("", NaN as any);
                 },
                 expectedError,
             );
 
             assert.throws(
                 function () {
-                    const r = new RangePartitionResolver("", {} as any);
+                    return new RangePartitionResolver("", {} as any);
                 },
                 expectedError,
             );
-
-            const rpr = new RangePartitionResolver("", new Array());
         });
 
         it("valid RangePartitionResolver", function (done) {
@@ -211,7 +209,7 @@ describe("RangePartitionResolver", function () {
 
             assert.throws(
                 function () {
-                    const result = resolver.resolveForCreate("X");
+                    return resolver.resolveForCreate("X");
                 },
                 /Error: Invalid operation: A containing range for 'X,X' doesn't exist in the partition map./,
             );
@@ -344,7 +342,7 @@ describe("RangePartitionResolver", function () {
         const invalidCompareFunctionTest = function (compareFunction: any) {
             assert.throws(
                 function () {
-                    const resolver = new RangePartitionResolver(
+                    return new RangePartitionResolver(
                         "key",
                         [{ range: new Range({ low: "A" }), link: "link1" }],
                         compareFunction,
@@ -382,12 +380,12 @@ describe("RangePartitionResolver", function () {
             const resolver = new RangePartitionResolver(
                 "key",
                 [{ range: new Range({ low: "A" }), link: "link1" }],
-                function (a, b) { throw new Error("Compare error"); },
+                function () { throw new Error("Compare error"); },
             );
 
             assert.throws(
                 function () {
-                    const result = (resolver as any).resolveForRead("A", ["link1"]); // TODO: any
+                    return (resolver as any).resolveForRead("A", ["link1"]); // TODO: any
                 },
                 /Error: Compare error/);
         });

--- a/src/test/unit/sessionContainer.spec.ts
+++ b/src/test/unit/sessionContainer.spec.ts
@@ -1,10 +1,6 @@
 ﻿import * as assert from "assert";
 import { ResourceId } from "../../common";
 import { SessionContainer } from "../../sessionContainer";
-import testConfig from "./../common/_testConfig";
-
-const host = testConfig.host;
-const masterKey = testConfig.masterKey;
 
 describe("Session Container unit tests", function () {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
+    "noUnusedLocals": true,
     "outDir": "./lib",
     "preserveConstEnums": true,
     "removeComments": true,


### PR DESCRIPTION
This PR naively fixes all issues raised by enabling `noUnusedLocals` in the typescript compiler. Still, work to be done as it required removing several private properties that are likely being used or don't have test coverage