### PR TITLE
Update config to preserve comments

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,20 +6,12 @@
     "noImplicitAny": true,
     "outDir": "./lib",
     "preserveConstEnums": true,
-    "removeComments": true,
+    "removeComments": false,
     "target": "es6",
     "sourceMap": true,
     "newLine": "LF",
-    "lib": [
-      "es6",
-      "esnext.asynciterable"
-    ]
+    "lib": ["es6", "esnext.asynciterable"]
   },
-  "include": [
-    "./src/**/*",
-    "./test/**/*.spec.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["./src/**/*", "./test/**/*.spec.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Fixes #68 

Had to update the tsconfig to preserve comments so the docs get exported with the code so VS Code can render them.

Other changes are related to prettier, which I'm guessing we don't run on our config (I can revert them, if we don't like them)