### PR TITLE
Update the exported types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,34 @@
 import * as DocumentBase from "./documents";
+export {
+  ConnectionMode,
+  ConsistencyLevel,
+  ConnectionPolicy,
+  DatabaseAccount,
+  DataType,
+  Index,
+  IndexedPath,
+  IndexingMode,
+  IndexingPolicy,
+  IndexKind,
+  LocationsType,
+  MediaReadMode,
+  PartitionKey,
+  PartitionKeyDefinition,
+  PartitionKind,
+  PermissionMode,
+  QueryCompatibilityMode,
+  TriggerOperation,
+  TriggerType,
+  UserDefinedFunctionType
+} from "./documents";
 
-export { DocumentClient } from "./documentclient";
 export { DocumentBase, DocumentBase as AzureDocuments };
-export { Range, RangePartitionResolver } from "./range";
-export { HashPartitionResolver } from "./hash";
 export { Constants, UriFactory } from "./common";
-export { Base } from "./base";
 export { RetryOptions } from "./retry";
 export { Response, RequestOptions, FeedOptions, MediaOptions, ErrorResponse } from "./request/";
-
-export { IHeaders } from "./queryExecutionContext";
+export { IHeaders, SqlParameter, SqlQuerySpec } from "./queryExecutionContext";
 export { QueryIterator } from "./queryIterator";
-
+export * from "./queryMetrics";
 export { CosmosClient } from "./CosmosClient";
 export { CosmosClientOptions } from "./CosmosClientOptions";
 export * from "./client/";

--- a/src/test/functional/HashPartitionResolver.spec.ts
+++ b/src/test/functional/HashPartitionResolver.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as Stream from "stream";
-import { CosmosClient, HashPartitionResolver } from "../../";
+import { HashPartitionResolver } from "../../hash/";
 import { removeAllDatabases } from "./../common/TestHelpers";
 
 describe("NodeJS CRUD Tests", function() {

--- a/src/test/integration/authorization.spec.ts
+++ b/src/test/integration/authorization.spec.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { Base, Container, CosmosClient, DocumentBase, UriFactory } from "../../";
+import { Container, CosmosClient, DocumentBase } from "../../";
 import { Database } from "../../client";
 import { endpoint } from "./../common/_testConfig";
 import { getTestContainer, removeAllDatabases } from "./../common/TestHelpers";

--- a/src/test/integration/proxy.spec.ts
+++ b/src/test/integration/proxy.spec.ts
@@ -1,8 +1,9 @@
 ﻿import * as http from "http";
 import * as net from "net";
 import * as url from "url";
-import { Base, CosmosClient, DocumentBase } from "../../";
+import { CosmosClient, DocumentBase } from "../../";
 import { endpoint, masterKey } from "./../common/_testConfig";
+import { addEntropy } from "./../common/TestHelpers";
 
 const isBrowser = new Function("try {return this===window;}catch(e){ return false;}");
 if (!isBrowser()) {
@@ -41,7 +42,7 @@ if (!isBrowser()) {
             });
             // create database
             await client.databases.create({
-              id: Base.generateGuidId()
+              id: addEntropy("ProxyTest")
             });
             resolve();
           } catch (err) {
@@ -65,7 +66,7 @@ if (!isBrowser()) {
             });
             // create database
             await client.databases.create({
-              id: Base.generateGuidId()
+              id: addEntropy("ProxyTest")
             });
             reject(new Error("Should create database in error while the proxy setting is not correct"));
           } catch (err) {

--- a/src/test/integration/session.spec.ts
+++ b/src/test/integration/session.spec.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
-import { Base, Constants, CosmosClient, IHeaders } from "../../";
+import { Constants, CosmosClient, IHeaders } from "../../";
+import { Base } from "../../base";
 import { ConsistencyLevel, PartitionKind } from "../../documents";
 import { endpoint, masterKey } from "./../common/_testConfig";
 import { getTestDatabase, removeAllDatabases } from "./../common/TestHelpers";

--- a/src/test/unit/base.spec.ts
+++ b/src/test/unit/base.spec.ts
@@ -1,7 +1,7 @@
 ﻿import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
-import { Base } from "../../";
+import { Base } from "../../base";
 import content from "./../common/BaselineTest.PathParser";
 
 describe("Base", function() {

--- a/src/test/unit/range.spec.ts
+++ b/src/test/unit/range.spec.ts
@@ -1,5 +1,5 @@
 ﻿import * as assert from "assert";
-import { Range } from "../../";
+import { Range } from "../../range";
 
 describe("Range Tests", function() {
   describe("constructor", function() {

--- a/src/test/unit/rangePartitionResolver.spec.ts
+++ b/src/test/unit/rangePartitionResolver.spec.ts
@@ -1,5 +1,5 @@
 ﻿import * as assert from "assert";
-import { Range, RangePartitionResolver } from "../../";
+import { Range, RangePartitionResolver } from "../../range";
 import { CompareFunction } from "../../range";
 
 describe("RangePartitionResolver", function() {


### PR DESCRIPTION
Makes the index.ts match the types that we cover in our Reference Docs. It also expands everything under DocumentBase to be its own level of types.