### PR TITLE
Change all string enum properties to keyof typof enum properties

### DIFF
--- a/samples/IndexManagement/app.js
+++ b/samples/IndexManagement/app.js
@@ -196,7 +196,11 @@ async function useLazyIndexing(database) {
 
   // allowed values for IndexingMode are consistent (default), lazy and none
   const containerId = "LazyIndexDemo";
-  const indexingPolicySpec = { indexingMode: cosmos.DocumentBase.IndexingMode.Lazy };
+  /** @type cosmos.DocumentBase.IndexingPolicy */
+  const indexingPolicySpec = { indexingMode: cosmos.DocumentBase.IndexingMode.lazy };
+
+  // You can also set the indexing policy Mode via string
+  indexingPolicySpec.indexingMode = "lazy";
 
   const { body: containerDef, container } = await database.containers.create({
     id: containerId,

--- a/src/CosmosClient.ts
+++ b/src/CosmosClient.ts
@@ -2,7 +2,7 @@ import { Database, Databases } from "./client/Database/";
 import { Offer, Offers } from "./client/Offer/";
 import { CosmosClientOptions } from "./CosmosClientOptions";
 import { DocumentClient } from "./documentclient";
-import { DatabaseAccount } from "./documents";
+import { ConsistencyLevel, DatabaseAccount } from "./documents";
 import { CosmosResponse } from "./request";
 
 /**
@@ -59,7 +59,7 @@ export class CosmosClient {
       options.endpoint,
       options.auth,
       options.connectionPolicy,
-      options.consistencyLevel
+      ConsistencyLevel[options.consistencyLevel]
     );
   }
 

--- a/src/CosmosClientOptions.ts
+++ b/src/CosmosClientOptions.ts
@@ -22,5 +22,5 @@ export interface CosmosClientOptions {
   /** An optional parameter that represents the consistency level.
    * It can take any value from {@link ConsistencyLevel}.
    */
-  consistencyLevel?: ConsistencyLevel;
+  consistencyLevel?: keyof typeof ConsistencyLevel;
 }

--- a/src/documents/ConnectionPolicy.ts
+++ b/src/documents/ConnectionPolicy.ts
@@ -10,7 +10,7 @@ export class ConnectionPolicy {
   /** Determines which mode to connect to Cosmos with. (Currently only supports Gateway option) */
   public ConnectionMode = ConnectionMode.Gateway;
   /** Attachment content (aka media) download mode. Should be one of the values of {@link MediaReadMode} */
-  public MediaReadMode = MediaReadMode.Buffered;
+  public MediaReadMode: keyof typeof MediaReadMode = MediaReadMode.Buffered;
 
   /** Time to wait for response from network peer for attachment content (aka media) operations. Represented in milliseconds. */
   public MediaRequestTimeout = ConnectionPolicy.defaultMediaRequestTimeout;

--- a/src/documents/IndexingMode.ts
+++ b/src/documents/IndexingMode.ts
@@ -5,16 +5,18 @@
  */
 export enum IndexingMode {
   /**
-   * <p>Index is updated synchronously with a create or update operation. <br>
+   * Index is updated synchronously with a create or update operation.
+   *
    * With consistent indexing, query behavior is the same as the default consistency level for the container.
-   * The index is always kept up to date with the data. </p>
+   * The index is always kept up to date with the data.
    */
-  Consistent = "consistent",
+  consistent = "consistent",
   /**
-   * <p>Index is updated asynchronously with respect to a create or update operation. <br>
-   * With lazy indexing, queries are eventually consistent. The index is updated when the container is idle.</p>
+   * Index is updated asynchronously with respect to a create or update operation.
+   *
+   * With lazy indexing, queries are eventually consistent. The index is updated when the container is idle.
    */
-  Lazy = "lazy",
+  lazy = "lazy",
   /** No Index is provided. */
-  None = "none"
+  none = "none"
 }

--- a/src/documents/IndexingPolicy.ts
+++ b/src/documents/IndexingPolicy.ts
@@ -2,7 +2,7 @@ import { DataType, IndexingMode, IndexKind } from ".";
 
 export interface IndexingPolicy {
   /** The indexing mode (consistent or lazy) {@link IndexingMode}. */
-  indexingMode?: IndexingMode;
+  indexingMode?: keyof typeof IndexingMode;
   automatic?: boolean;
   /** An array of {@link IncludedPath} represents the paths to be included for indexing. */
   includedPaths?: IndexedPath[];
@@ -16,7 +16,7 @@ export interface IndexedPath {
 }
 
 export interface Index {
-  kind: IndexKind;
-  dataType: DataType;
+  kind: keyof typeof IndexKind;
+  dataType: keyof typeof DataType;
   precision?: number;
 }

--- a/src/documents/PartitionKeyDefinition.ts
+++ b/src/documents/PartitionKeyDefinition.ts
@@ -2,5 +2,5 @@ import { PartitionKind } from ".";
 
 export interface PartitionKeyDefinition {
   paths: string[];
-  kind: PartitionKind;
+  kind: keyof typeof PartitionKind;
 }

--- a/src/test/functional/container.spec.ts
+++ b/src/test/functional/container.spec.ts
@@ -19,7 +19,7 @@ describe("NodeJS CRUD Tests", function() {
         // create a container
         const containerDefinition: ContainerDefinition = {
           id: "sample container",
-          indexingPolicy: { indexingMode: IndexingMode.Consistent }
+          indexingPolicy: { indexingMode: IndexingMode.consistent }
         };
 
         if (hasPartitionKey) {
@@ -49,7 +49,7 @@ describe("NodeJS CRUD Tests", function() {
         assert(results.length > 0, "number of results for the query should be > 0");
 
         // Replacing indexing policy is allowed.
-        containerDef.indexingPolicy.indexingMode = IndexingMode.Lazy;
+        containerDef.indexingPolicy.indexingMode = IndexingMode.lazy;
         const { body: replacedContainer } = await container.replace(containerDef);
         assert.equal("lazy", replacedContainer.indexingPolicy.indexingMode);
 
@@ -108,7 +108,7 @@ describe("NodeJS CRUD Tests", function() {
 
         const containerDefinition: ContainerDefinition = {
           id: "sample container",
-          indexingPolicy: { indexingMode: IndexingMode.Consistent },
+          indexingPolicy: { indexingMode: IndexingMode.consistent },
           partitionKey: badPartitionKeyDefinition // This is invalid, forced using type coersion
         };
 
@@ -167,14 +167,14 @@ describe("NodeJS CRUD Tests", function() {
 
         assert.equal(
           containerDef.indexingPolicy.indexingMode,
-          DocumentBase.IndexingMode.Consistent,
+          DocumentBase.IndexingMode.consistent,
           "default indexing mode should be consistent"
         );
         await container.delete();
 
         const lazyContainerDefinition: ContainerDefinition = {
           id: "lazy container",
-          indexingPolicy: { indexingMode: DocumentBase.IndexingMode.Lazy }
+          indexingPolicy: { indexingMode: DocumentBase.IndexingMode.lazy }
         };
 
         const { body: lazyContainerDef } = await database.containers.create(lazyContainerDefinition);
@@ -182,7 +182,7 @@ describe("NodeJS CRUD Tests", function() {
 
         assert.equal(
           lazyContainerDef.indexingPolicy.indexingMode,
-          DocumentBase.IndexingMode.Lazy,
+          DocumentBase.IndexingMode.lazy,
           "indexing mode should be lazy"
         );
 
@@ -190,13 +190,13 @@ describe("NodeJS CRUD Tests", function() {
 
         const consistentcontainerDefinition: ContainerDefinition = {
           id: "lazy container",
-          indexingPolicy: { indexingMode: DocumentBase.IndexingMode.Consistent }
+          indexingPolicy: { indexingMode: "consistent" } // tests the type flexibility
         };
         const { body: consistentContainerDef } = await database.containers.create(consistentcontainerDefinition);
         const consistentContainer = database.container(consistentContainerDef.id);
         assert.equal(
           containerDef.indexingPolicy.indexingMode,
-          DocumentBase.IndexingMode.Consistent,
+          DocumentBase.IndexingMode.consistent,
           "indexing mode should be consistent"
         );
         await consistentContainer.delete();
@@ -205,7 +205,7 @@ describe("NodeJS CRUD Tests", function() {
           id: "containerWithIndexingPolicy",
           indexingPolicy: {
             automatic: true,
-            indexingMode: DocumentBase.IndexingMode.Consistent,
+            indexingMode: DocumentBase.IndexingMode.consistent,
             includedPaths: [
               {
                 path: "/",
@@ -311,7 +311,7 @@ describe("NodeJS CRUD Tests", function() {
         const containerDefinition02: ContainerDefinition = {
           id: "TestCreateDefaultPolicy02",
           indexingPolicy: {
-            indexingMode: IndexingMode.Lazy,
+            indexingMode: IndexingMode.lazy,
             automatic: true
           }
         };
@@ -398,7 +398,7 @@ describe("NodeJS CRUD Tests", function() {
 
         const lazyContainerDefinition = {
           id: "lazy_coll",
-          indexingPolicy: { indexingMode: DocumentBase.IndexingMode.Lazy }
+          indexingPolicy: { indexingMode: DocumentBase.IndexingMode.lazy }
         };
         const { headers: headers2 } = await createThenReadcontainer(database, lazyContainerDefinition);
         assert.notEqual(headers2[Constants.HttpHeaders.IndexTransformationProgress], undefined);
@@ -406,7 +406,7 @@ describe("NodeJS CRUD Tests", function() {
 
         const noneContainerDefinition = {
           id: "none_coll",
-          indexingPolicy: { indexingMode: DocumentBase.IndexingMode.None, automatic: false }
+          indexingPolicy: { indexingMode: DocumentBase.IndexingMode.none, automatic: false }
         };
         const { headers: headers3 } = await createThenReadcontainer(database, noneContainerDefinition);
         assert.notEqual(headers3[Constants.HttpHeaders.IndexTransformationProgress], undefined);

--- a/src/test/integration/encoding.spec.ts
+++ b/src/test/integration/encoding.spec.ts
@@ -27,7 +27,7 @@ describe("Create And Read Validation", function() {
       const database = await getTestDatabase(databaseId);
       const containerBody = {
         id: "डेटाबेस پایگاه داده 数据库" + dateTime.getTime(),
-        indexingPolicy: { indexingMode: IndexingMode.Lazy } // Modes : Lazy, Consistent
+        indexingPolicy: { indexingMode: IndexingMode.lazy } // Modes : Lazy, Consistent
       };
 
       // Create a container inside the database


### PR DESCRIPTION
fixes https://github.com/Azure/azure-cosmos-js/issues/72

moves all the properties that required enum types to now support `keyof typeof enum`, which allows for strings to be used directly, not just the direct enum reference (which was really heavy for JS users)

e.g.
Before:
```ts
const indexKind: IndexKind = IndexKind.Range; // ✔
const indexKind: IndexKind = "Range"; // ❌
 ```

After:
```ts
const indexKind: keyof typeof IndexKind = IndexKind.Range; // ✔
const indexKind: keyof typeof IndexKind = "Range"; // ✔
const indexKind: keyof typeof IndexKind = "badIndexKind"; // ❌still gives errors properly
```
