### PR TITLE
Update to Readme.md. Correct call `client.databases.create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ const collectionDefinition = { id: "sample collection" };
 const itemDefinition = { id: "hello world doc", content: "Hello World!" };
 
 async function helloCosmos() {
-    const { database: db } = await client.database.create(databaseDefinition);
+    const { database: db } = await client.databases.create(databaseDefinition);
     console.log('created db');
 
-    const { container } = await db.container.create(collectionDefinition);
+    const { container } = await db.containers.create(collectionDefinition);
     console.log('created collection');
 
     const { body } = await container.items.create(documentDefinition);

--- a/src/test/functional/container.spec.ts
+++ b/src/test/functional/container.spec.ts
@@ -426,11 +426,11 @@ describe("NodeJS CRUD Tests", function() {
   });
 });
 
-describe("container.createIfNotExists", function() {
+describe("containers.createIfNotExists", function() {
   let database: Database;
   before(async function() {
     // create database
-    database = await getTestDatabase("container.createIfNotExists");
+    database = await getTestDatabase("containers.createIfNotExists");
   });
 
   it("should handle container does not exist", async function() {

--- a/src/test/functional/database.spec.ts
+++ b/src/test/functional/database.spec.ts
@@ -55,7 +55,7 @@ describe("NodeJS CRUD Tests", function() {
       await databaseCRUDTest();
     });
 
-    describe("database.createIfNotExists", function() {
+    describe("databases.createIfNotExists", function() {
       it("should handle does not exist", async function() {
         const def: DatabaseDefinition = { id: addEntropy("does not exist") };
         const { database } = await client.databases.createIfNotExists(def);


### PR DESCRIPTION
Fixes readme file to call `client.databases.create` instead of `client.database.create`. Also fixes test names that may be confusing.