### PR TITLE
Update response types

### DIFF
--- a/src/ClientContext.ts
+++ b/src/ClientContext.ts
@@ -1,4 +1,5 @@
 import { Constants, CosmosClientOptions, IHeaders, QueryIterator, RequestOptions, Response, SqlQuerySpec } from ".";
+import { Resource } from "./client/Resource";
 import { Helper, StatusCodes, SubStatusCodes } from "./common";
 import { ConnectionPolicy, ConsistencyLevel, DatabaseAccount, QueryCompatibilityMode } from "./documents";
 import { GlobalEndpointManager } from "./globalEndpointManager";
@@ -39,7 +40,7 @@ export class ClientContext {
     id: string,
     initialHeaders: IHeaders,
     options?: RequestOptions
-  ): Promise<Response<T>> {
+  ): Promise<Response<T & Resource>> {
     try {
       const requestHeaders = await getHeaders(
         this.cosmosClientOptions.auth,
@@ -72,7 +73,7 @@ export class ClientContext {
     }
   }
 
-  public async queryFeed(
+  public async queryFeed<T>(
     path: string,
     type: string, // TODO: code smell: enum?
     id: string,
@@ -80,7 +81,7 @@ export class ClientContext {
     query: SqlQuerySpec | string,
     options: FeedOptions,
     partitionKeyRangeId?: string
-  ): Promise<Response<any>> {
+  ): Promise<Response<T & Resource>> {
     // Query operations will use ReadEndpoint even though it uses
     // GET(for queryFeed) and POST(for regular query operations)
 
@@ -163,7 +164,7 @@ export class ClientContext {
     id: string,
     initialHeaders: IHeaders,
     options?: RequestOptions
-  ): Promise<Response<T>> {
+  ): Promise<Response<T & Resource>> {
     try {
       const reqHeaders = await getHeaders(
         this.cosmosClientOptions.auth,
@@ -200,6 +201,7 @@ export class ClientContext {
     }
   }
 
+  // Most cases, things return the defintion + the system resource props
   public async create<T>(
     body: T,
     path: string,
@@ -207,7 +209,25 @@ export class ClientContext {
     id: string,
     initialHeaders: IHeaders,
     options?: RequestOptions
-  ): Promise<Response<T>> {
+  ): Promise<Response<T & Resource>>;
+
+  // But a few cases, like permissions, there is additional junk added to the response that isn't in system resource props
+  public async create<T, U>(
+    body: T,
+    path: string,
+    type: string,
+    id: string,
+    initialHeaders: IHeaders,
+    options?: RequestOptions
+  ): Promise<Response<T & U & Resource>>;
+  public async create<T, U>(
+    body: T,
+    path: string,
+    type: string,
+    id: string,
+    initialHeaders: IHeaders,
+    options?: RequestOptions
+  ): Promise<Response<T & U & Resource>> {
     try {
       const requestHeaders = await getHeaders(
         this.cosmosClientOptions.auth,
@@ -285,7 +305,7 @@ export class ClientContext {
     id: string,
     initialHeaders: IHeaders,
     options?: RequestOptions
-  ): Promise<Response<T>> {
+  ): Promise<Response<T & Resource>> {
     try {
       const reqHeaders = await getHeaders(
         this.cosmosClientOptions.auth,
@@ -326,7 +346,23 @@ export class ClientContext {
     id: string,
     initialHeaders: IHeaders,
     options?: RequestOptions
-  ): Promise<Response<T>> {
+  ): Promise<Response<T & Resource>>;
+  public async upsert<T, U>(
+    body: T,
+    path: string,
+    type: string,
+    id: string,
+    initialHeaders: IHeaders,
+    options?: RequestOptions
+  ): Promise<Response<T & U & Resource>>;
+  public async upsert<T>(
+    body: T,
+    path: string,
+    type: string,
+    id: string,
+    initialHeaders: IHeaders,
+    options?: RequestOptions
+  ): Promise<Response<T & Resource>> {
     try {
       const requestHeaders = await getHeaders(
         this.cosmosClientOptions.auth,

--- a/src/client/Conflict/Conflict.ts
+++ b/src/client/Conflict/Conflict.ts
@@ -2,6 +2,7 @@ import { ClientContext } from "../../ClientContext";
 import { Constants, Helper } from "../../common";
 import { RequestOptions } from "../../request";
 import { Container } from "../Container";
+import { ConflictDefinition } from "./ConflictDefinition";
 import { ConflictResponse } from "./ConflictResponse";
 
 /**
@@ -35,7 +36,7 @@ export class Conflict {
     const path = Helper.getPathFromLink(this.url, "conflicts");
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.read(path, "users", id, undefined, options);
+    const response = await this.clientContext.read<ConflictDefinition>(path, "users", id, undefined, options);
     return { body: response.result, headers: response.headers, ref: this, conflict: this };
   }
 
@@ -47,7 +48,7 @@ export class Conflict {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.delete(path, "conflicts", id, undefined, options);
+    const response = await this.clientContext.delete<ConflictDefinition>(path, "conflicts", id, undefined, options);
     return { body: response.result, headers: response.headers, ref: this, conflict: this };
   }
 }

--- a/src/client/Conflict/ConflictResponse.ts
+++ b/src/client/Conflict/ConflictResponse.ts
@@ -1,8 +1,9 @@
 import { CosmosResponse } from "../../request";
+import { Resource } from "../Resource";
 import { Conflict } from "./Conflict";
 import { ConflictDefinition } from "./ConflictDefinition";
 
-export interface ConflictResponse extends CosmosResponse<ConflictDefinition, Conflict> {
+export interface ConflictResponse extends CosmosResponse<ConflictDefinition & Resource, Conflict> {
   /** A reference to the {@link Conflict} corresponding to the returned {@link ConflictDefinition}. */
   conflict: Conflict;
 }

--- a/src/client/Conflict/Conflicts.ts
+++ b/src/client/Conflict/Conflicts.ts
@@ -4,6 +4,7 @@ import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions } from "../../request";
 import { Container } from "../Container";
+import { Resource } from "../Resource";
 import { ConflictDefinition } from "./ConflictDefinition";
 
 /**
@@ -14,7 +15,21 @@ import { ConflictDefinition } from "./ConflictDefinition";
 export class Conflicts {
   constructor(public readonly container: Container, private readonly clientContext: ClientContext) {}
 
-  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<ConflictDefinition> {
+  /**
+   * Queries all conflicts.
+   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @returns {@link QueryIterator} Allows you to return results in an array or iterate over them one at a time.
+   */
+  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
+  /**
+   * Queries all conflicts.
+   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options Use to set options like response page size, continuation tokens, etc.
+   * @returns {@link QueryIterator} Allows you to return results in an array or iterate over them one at a time.
+   */
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
     const path = Helper.getPathFromLink(this.container.url, "conflicts");
     const id = Helper.getIdFromLink(this.container.url);
 
@@ -23,7 +38,11 @@ export class Conflicts {
     });
   }
 
-  public readAll(options?: FeedOptions): QueryIterator<ConflictDefinition> {
-    return this.query(undefined, options);
+  /**
+   * Reads all conflicts
+   * @param options Use to set options like response page size, continuation tokens, etc.
+   */
+  public readAll(options?: FeedOptions): QueryIterator<ConflictDefinition & Resource> {
+    return this.query<ConflictDefinition & Resource>(undefined, options);
   }
 }

--- a/src/client/Container/Container.ts
+++ b/src/client/Container/Container.ts
@@ -159,7 +159,7 @@ export class Container {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.replace(body, path, "colls", id, undefined, options);
+    const response = await this.clientContext.replace<ContainerDefinition>(body, path, "colls", id, undefined, options);
     return {
       body: response.result,
       headers: response.headers,
@@ -173,7 +173,7 @@ export class Container {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.delete(path, "colls", id, undefined, options);
+    const response = await this.clientContext.delete<ContainerDefinition>(path, "colls", id, undefined, options);
     return {
       body: response.result,
       headers: response.headers,

--- a/src/client/Container/ContainerResponse.ts
+++ b/src/client/Container/ContainerResponse.ts
@@ -1,9 +1,10 @@
 import { Container } from ".";
 import { CosmosResponse } from "../../request/CosmosResponse";
+import { Resource } from "../Resource";
 import { ContainerDefinition } from "./ContainerDefinition";
 
 /** Response object for Container operations */
-export interface ContainerResponse extends CosmosResponse<ContainerDefinition, Container> {
+export interface ContainerResponse extends CosmosResponse<ContainerDefinition & Resource, Container> {
   /** A reference to the {@link Container} that the returned {@link ContainerDefinition} corresponds to. */
   container: Container;
 }

--- a/src/client/Database/Database.ts
+++ b/src/client/Database/Database.ts
@@ -4,6 +4,7 @@ import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions } from "../../request";
 import { Container, Containers } from "../Container";
 import { User, Users } from "../User";
+import { DatabaseDefinition } from "./DatabaseDefinition";
 import { DatabaseResponse } from "./DatabaseResponse";
 
 /**
@@ -78,7 +79,7 @@ export class Database {
   public async read(options?: RequestOptions): Promise<DatabaseResponse> {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
-    const response = await this.clientContext.read(path, "dbs", id, undefined, options);
+    const response = await this.clientContext.read<DatabaseDefinition>(path, "dbs", id, undefined, options);
     return {
       body: response.result,
       headers: response.headers,
@@ -91,7 +92,7 @@ export class Database {
   public async delete(options?: RequestOptions): Promise<DatabaseResponse> {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
-    const response = await this.clientContext.delete(path, "dbs", id, undefined, options);
+    const response = await this.clientContext.delete<DatabaseDefinition>(path, "dbs", id, undefined, options);
     return {
       body: response.result,
       headers: response.headers,

--- a/src/client/Database/DatabaseResponse.ts
+++ b/src/client/Database/DatabaseResponse.ts
@@ -1,9 +1,10 @@
 import { CosmosResponse } from "../../request/CosmosResponse";
+import { Resource } from "../Resource";
 import { Database } from "./Database";
 import { DatabaseDefinition } from "./DatabaseDefinition";
 
 /** Response object for Database operations */
-export interface DatabaseResponse extends CosmosResponse<DatabaseDefinition, Database> {
+export interface DatabaseResponse extends CosmosResponse<DatabaseDefinition & Resource, Database> {
   /** A reference to the {@link Database} that the returned {@link DatabaseDefinition} corresponds to. */
   database: Database;
 }

--- a/src/client/Item/Item.ts
+++ b/src/client/Item/Item.ts
@@ -1,9 +1,8 @@
 import { ClientContext } from "../../ClientContext";
 import { Helper, UriFactory } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
-import { RequestOptions, Response } from "../../request";
+import { RequestOptions } from "../../request";
 import { Container } from "../Container";
-import { ItemBody } from "./ItemBody";
+import { Resource } from "../Resource";
 import { ItemDefinition } from "./ItemDefinition";
 import { ItemResponse } from "./ItemResponse";
 
@@ -75,10 +74,10 @@ export class Item {
     }
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
-    const response = await this.clientContext.read(path, "docs", id, undefined, options);
+    const response = await this.clientContext.read<T>(path, "docs", id, undefined, options);
 
     return {
-      body: response.result as T & ItemBody,
+      body: response.result,
       headers: response.headers,
       ref: this,
       item: this
@@ -124,7 +123,7 @@ export class Item {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.replace<T & ItemBody>(body, path, "docs", id, undefined, options);
+    const response = await this.clientContext.replace<T>(body, path, "docs", id, undefined, options);
     return {
       body: response.result,
       headers: response.headers,
@@ -155,7 +154,7 @@ export class Item {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.delete<T & ItemBody>(path, "docs", id, undefined, options);
+    const response = await this.clientContext.delete<T>(path, "docs", id, undefined, options);
     return {
       body: response.result,
       headers: response.headers,

--- a/src/client/Item/ItemResponse.ts
+++ b/src/client/Item/ItemResponse.ts
@@ -1,9 +1,9 @@
 import { CosmosResponse } from "../../request/CosmosResponse";
+import { Resource } from "../Resource";
 import { Item } from "./Item";
-import { ItemBody } from "./ItemBody";
 import { ItemDefinition } from "./ItemDefinition";
 
-export interface ItemResponse<T extends ItemDefinition> extends CosmosResponse<T & ItemBody, Item> {
+export interface ItemResponse<T extends ItemDefinition> extends CosmosResponse<T & Resource, Item> {
   /** Reference to the {@link Item} the response corresponds to. */
   item: Item;
 }

--- a/src/client/Item/Items.ts
+++ b/src/client/Item/Items.ts
@@ -4,8 +4,8 @@ import { FetchFunctionCallback, SqlQuerySpec } from "../../queryExecutionContext
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
 import { Container } from "../Container";
+import { Resource } from "../Resource";
 import { Item } from "./Item";
-import { ItemBody } from "./ItemBody";
 import { ItemDefinition } from "./ItemDefinition";
 import { ItemResponse } from "./ItemResponse";
 
@@ -34,10 +34,10 @@ export class Items {
    *     {name: "@lastName", value: "Hendricks"}
    *   ]
    * };
-   * const {body: containerList} = await items.query.toArray();
+   * const {result: items} = await items.query(querySpec).toArray();
    * ```
    */
-  public query(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<ItemDefinition>;
+  public query(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
   /**
    * Queries all items.
    * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
@@ -45,16 +45,16 @@ export class Items {
    * @example Read all items to array.
    * ```typescript
    * const querySpec: SqlQuerySpec = {
-   *   query: "SELECT * FROM Families f WHERE f.lastName = @lastName",
+   *   query: "SELECT firstname FROM Families f WHERE f.lastName = @lastName",
    *   parameters: [
    *     {name: "@lastName", value: "Hendricks"}
    *   ]
    * };
-   * const {body: containerList} = await items.query.toArray();
+   * const {result: items} = await items.query<{firstName: string}>(querySpec).toArray();
    * ```
    */
-  public query<T extends ItemDefinition>(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
-  public query<T extends ItemDefinition>(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
+  public query<T>(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
+  public query<T>(query: string | SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
     const path = Helper.getPathFromLink(this.container.url, "docs");
     const id = Helper.getIdFromLink(this.container.url);
 
@@ -144,7 +144,7 @@ export class Items {
     const path = Helper.getPathFromLink(this.container.url, "docs");
     const id = Helper.getIdFromLink(this.container.url);
 
-    const response = await this.clientContext.create(body, path, "docs", id, undefined, options);
+    const response = await this.clientContext.create<T>(body, path, "docs", id, undefined, options);
 
     const ref = new Item(
       this.container,
@@ -153,7 +153,7 @@ export class Items {
       this.clientContext
     );
     return {
-      body: response.result as T & ItemBody,
+      body: response.result,
       headers: response.headers,
       ref,
       item: ref
@@ -201,7 +201,7 @@ export class Items {
     const path = Helper.getPathFromLink(this.container.url, "docs");
     const id = Helper.getIdFromLink(this.container.url);
 
-    const response = (await this.clientContext.upsert<T>(body, path, "docs", id, undefined, options)) as T & ItemBody;
+    const response = (await this.clientContext.upsert<T>(body, path, "docs", id, undefined, options)) as T & Resource;
 
     const ref = new Item(
       this.container,

--- a/src/client/Offer/Offer.ts
+++ b/src/client/Offer/Offer.ts
@@ -33,7 +33,7 @@ export class Offer {
    * @param options
    */
   public async read(options?: RequestOptions): Promise<OfferResponse> {
-    const response = await this.clientContext.read(this.url, "offers", this.id, undefined, options);
+    const response = await this.clientContext.read<OfferDefinition>(this.url, "offers", this.id, undefined, options);
     return { body: response.result, headers: response.headers, ref: this, offer: this };
   }
 
@@ -47,7 +47,14 @@ export class Offer {
     if (!Helper.isResourceValid(body, err)) {
       throw err;
     }
-    const response = await this.clientContext.replace(body, this.url, "offers", this.id, undefined, options);
+    const response = await this.clientContext.replace<OfferDefinition>(
+      body,
+      this.url,
+      "offers",
+      this.id,
+      undefined,
+      options
+    );
     return { body: response.result, headers: response.headers, ref: this, offer: this };
   }
 }

--- a/src/client/Offer/OfferResponse.ts
+++ b/src/client/Offer/OfferResponse.ts
@@ -1,8 +1,9 @@
 import { CosmosResponse } from "../../request";
+import { Resource } from "../Resource";
 import { Offer } from "./Offer";
 import { OfferDefinition } from "./OfferDefinition";
 
-export interface OfferResponse extends CosmosResponse<OfferDefinition, Offer> {
+export interface OfferResponse extends CosmosResponse<OfferDefinition & Resource, Offer> {
   /** A reference to the {@link Offer} corresponding to the returned {@link OfferDefinition}. */
   offer: Offer;
 }

--- a/src/client/Offer/Offers.ts
+++ b/src/client/Offer/Offers.ts
@@ -3,6 +3,7 @@ import { CosmosClient } from "../../CosmosClient";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions } from "../../request";
+import { Resource } from "../Resource";
 import { OfferDefinition } from "./OfferDefinition";
 
 /**
@@ -13,7 +14,7 @@ import { OfferDefinition } from "./OfferDefinition";
 export class Offers {
   /**
    * @hidden
-   * @param client The parent {@link CosmosClient} for the Database Account.
+   * @param client The parent {@link CosmosClient} for the offers.
    */
   constructor(public readonly client: CosmosClient, private readonly clientContext: ClientContext) {}
 
@@ -22,9 +23,16 @@ export class Offers {
    * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    * @param options
    */
-  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<OfferDefinition> {
+  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
+  /**
+   * Query all offers.
+   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options
+   */
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
     return new QueryIterator(this.clientContext, query, options, innerOptions => {
-      return this.clientContext.queryFeed("/offers", "offers", "", result => result.Offers, query, innerOptions);
+      return this.clientContext.queryFeed<T>("/offers", "offers", "", result => result.Offers, query, innerOptions);
     });
   }
 
@@ -36,7 +44,7 @@ export class Offers {
    * const {body: offerList} = await client.offers.readAll().toArray();
    * ```
    */
-  public readAll(options?: FeedOptions): QueryIterator<OfferDefinition> {
-    return this.query(undefined, options);
+  public readAll(options?: FeedOptions): QueryIterator<OfferDefinition & Resource> {
+    return this.query<OfferDefinition & Resource>(undefined, options);
   }
 }

--- a/src/client/Permission/Permission.ts
+++ b/src/client/Permission/Permission.ts
@@ -1,6 +1,5 @@
 import { ClientContext } from "../../ClientContext";
 import { Helper, UriFactory } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions } from "../../request/RequestOptions";
 import { User } from "../User";
 import { PermissionBody } from "./PermissionBody";
@@ -34,9 +33,15 @@ export class Permission {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.read<PermissionDefinition>(path, "permissions", id, undefined, options);
+    const response = await this.clientContext.read<PermissionDefinition & PermissionBody>(
+      path,
+      "permissions",
+      id,
+      undefined,
+      options
+    );
     return {
-      body: response.result as PermissionDefinition & PermissionBody,
+      body: response.result,
       headers: response.headers,
       ref: this,
       permission: this
@@ -57,9 +62,16 @@ export class Permission {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.replace(body, path, "permissions", id, undefined, options);
+    const response = await this.clientContext.replace<PermissionDefinition & PermissionBody>(
+      body,
+      path,
+      "permissions",
+      id,
+      undefined,
+      options
+    );
     return {
-      body: response.result as PermissionDefinition & PermissionBody,
+      body: response.result,
       headers: response.headers,
       ref: this,
       permission: this
@@ -74,9 +86,15 @@ export class Permission {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.delete(path, "permissions", id, undefined, options);
+    const response = await this.clientContext.delete<PermissionDefinition & PermissionBody>(
+      path,
+      "permissions",
+      id,
+      undefined,
+      options
+    );
     return {
-      body: response.result as PermissionDefinition & PermissionBody,
+      body: response.result,
       headers: response.headers,
       ref: this,
       permission: this

--- a/src/client/Permission/PermissionBody.ts
+++ b/src/client/Permission/PermissionBody.ts
@@ -1,15 +1,6 @@
-import { PermissionMode } from "../../documents";
-import { PermissionDefinition } from "./PermissionDefinition";
+import { Resource } from "../Resource";
 
-export interface PermissionBody extends PermissionDefinition {
-  /** System generated property. The resource ID (_rid) is a unique identifier that is also hierarchical per the resource stack on the resource model. It is used internally for placement and navigation of the permission resource. */
-  _rid: string;
-  /** System generated property. Specifies the last updated timestamp of the resource. The value is a timestamp. */
-  _ts: string;
-  /** System generated property. The unique addressable URI for the resource. */
-  _self: string;
-  /** System generated property. Represents the resource etag required for optimistic concurrency control. */
-  _etag: string;
+export interface PermissionBody {
   /** System generated resource token for the particular resource and user */
   _token: string;
 }

--- a/src/client/Permission/PermissionResponse.ts
+++ b/src/client/Permission/PermissionResponse.ts
@@ -1,8 +1,11 @@
 import { CosmosResponse } from "../../request";
+import { Resource } from "../Resource";
 import { Permission } from "./Permission";
 import { PermissionBody } from "./PermissionBody";
+import { PermissionDefinition } from "./PermissionDefinition";
 
-export interface PermissionResponse extends CosmosResponse<PermissionBody, Permission> {
+export interface PermissionResponse
+  extends CosmosResponse<PermissionDefinition & PermissionBody & Resource, Permission> {
   /** A reference to the {@link Permission} corresponding to the returned {@link PermissionDefinition}. */
   permission: Permission;
 }

--- a/src/client/Permission/Permissions.ts
+++ b/src/client/Permission/Permissions.ts
@@ -1,9 +1,9 @@
 import { ClientContext } from "../../ClientContext";
 import { Helper } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
+import { Resource } from "../Resource";
 import { User } from "../User";
 import { Permission } from "./Permission";
 import { PermissionBody } from "./PermissionBody";
@@ -27,7 +27,14 @@ export class Permissions {
    * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    * @param options
    */
-  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<PermissionDefinition> {
+  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
+  /**
+   * Query all permissions.
+   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options
+   */
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
     const path = Helper.getPathFromLink(this.user.url, "permissions");
     const id = Helper.getIdFromLink(this.user.url);
 
@@ -44,7 +51,7 @@ export class Permissions {
    * const {body: permissionList} = await user.permissions.readAll().toArray();
    * ```
    */
-  public readAll(options?: FeedOptions): QueryIterator<PermissionDefinition> {
+  public readAll(options?: FeedOptions): QueryIterator<PermissionDefinition & Resource> {
     return this.query(undefined, options);
   }
 
@@ -64,10 +71,17 @@ export class Permissions {
     const path = Helper.getPathFromLink(this.user.url, "permissions");
     const id = Helper.getIdFromLink(this.user.url);
 
-    const response = await this.clientContext.create(body, path, "permissions", id, undefined, options);
+    const response = await this.clientContext.create<PermissionDefinition, PermissionBody>(
+      body,
+      path,
+      "permissions",
+      id,
+      undefined,
+      options
+    );
     const ref = new Permission(this.user, response.result.id, this.clientContext);
     return {
-      body: response.result as PermissionDefinition & PermissionBody,
+      body: response.result,
       headers: response.headers,
       ref,
       permission: ref
@@ -89,10 +103,17 @@ export class Permissions {
     const path = Helper.getPathFromLink(this.user.url, "permissions");
     const id = Helper.getIdFromLink(this.user.url);
 
-    const response = await this.clientContext.upsert(body, path, "permissions", id, undefined, options);
+    const response = await this.clientContext.upsert<PermissionDefinition, PermissionBody>(
+      body,
+      path,
+      "permissions",
+      id,
+      undefined,
+      options
+    );
     const ref = new Permission(this.user, response.result.id, this.clientContext);
     return {
-      body: response.result as PermissionDefinition & PermissionBody,
+      body: response.result,
       headers: response.headers,
       ref,
       permission: ref

--- a/src/client/Resource.ts
+++ b/src/client/Resource.ts
@@ -1,4 +1,4 @@
-export interface ItemBody {
+export interface Resource {
   /** Required. User settable property. Unique name that identifies the item, that is, no two items share the same ID within a database. The id must not exceed 255 characters. */
   id: string;
   /** System generated property. The resource ID (_rid) is a unique identifier that is also hierarchical per the resource stack on the resource model. It is used internally for placement and navigation of the item resource. */
@@ -10,5 +10,4 @@ export interface ItemBody {
   /** System generated property. Represents the resource etag required for optimistic concurrency control. */
   _etag: string;
   /** System generated property. Specifies the addressable path for the attachments resource. */
-  _attachments: string;
 }

--- a/src/client/StoredProcedure/StoredProcedure.ts
+++ b/src/client/StoredProcedure/StoredProcedure.ts
@@ -36,7 +36,7 @@ export class StoredProcedure {
   public async read(options?: RequestOptions): Promise<StoredProcedureResponse> {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
-    const response = await this.clientContext.read(path, "sprocs", id, undefined, options);
+    const response = await this.clientContext.read<StoredProcedureDefinition>(path, "sprocs", id, undefined, options);
 
     return { body: response.result, headers: response.headers, ref: this, storedProcedure: this, sproc: this };
   }
@@ -59,7 +59,14 @@ export class StoredProcedure {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.replace(body, path, "sprocs", id, undefined, options);
+    const response = await this.clientContext.replace<StoredProcedureDefinition>(
+      body,
+      path,
+      "sprocs",
+      id,
+      undefined,
+      options
+    );
 
     return { body: response.result, headers: response.headers, ref: this, storedProcedure: this, sproc: this };
   }
@@ -72,7 +79,7 @@ export class StoredProcedure {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.delete(path, "sprocs", id, undefined, options);
+    const response = await this.clientContext.delete<StoredProcedureDefinition>(path, "sprocs", id, undefined, options);
     return { body: response.result, headers: response.headers, ref: this, storedProcedure: this, sproc: this };
   }
 

--- a/src/client/StoredProcedure/StoredProcedureResponse.ts
+++ b/src/client/StoredProcedure/StoredProcedureResponse.ts
@@ -1,8 +1,9 @@
 import { CosmosResponse } from "../../request";
+import { Resource } from "../Resource";
 import { StoredProcedure } from "./StoredProcedure";
 import { StoredProcedureDefinition } from "./StoredProcedureDefinition";
 
-export interface StoredProcedureResponse extends CosmosResponse<StoredProcedureDefinition, StoredProcedure> {
+export interface StoredProcedureResponse extends CosmosResponse<StoredProcedureDefinition & Resource, StoredProcedure> {
   /**
    * A reference to the {@link StoredProcedure} which the {@link StoredProcedureDefinition} corresponds to.
    */

--- a/src/client/StoredProcedure/StoredProcedures.ts
+++ b/src/client/StoredProcedure/StoredProcedures.ts
@@ -1,10 +1,10 @@
 import { ClientContext } from "../../ClientContext";
 import { Helper } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
 import { Container } from "../Container";
+import { Resource } from "../Resource";
 import { StoredProcedure } from "./StoredProcedure";
 import { StoredProcedureDefinition } from "./StoredProcedureDefinition";
 import { StoredProcedureResponse } from "./StoredProcedureResponse";
@@ -36,7 +36,24 @@ export class StoredProcedures {
    * const {body: sprocList} = await containers.storedProcedures.query(querySpec).toArray();
    * ```
    */
-  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<StoredProcedureDefinition> {
+  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
+  /**
+   * Query all Stored Procedures.
+   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options
+   * @example Read all stored procedures to array.
+   * ```typescript
+   * const querySpec: SqlQuerySpec = {
+   *   query: "SELECT * FROM root r WHERE r.id = @sproc",
+   *   parameters: [
+   *     {name: "@sproc", value: "Todo"}
+   *   ]
+   * };
+   * const {body: sprocList} = await containers.storedProcedures.query(querySpec).toArray();
+   * ```
+   */
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
     const path = Helper.getPathFromLink(this.container.url, "sprocs");
     const id = Helper.getIdFromLink(this.container.url);
 
@@ -53,8 +70,8 @@ export class StoredProcedures {
    * const {body: sprocList} = await containers.storedProcedures.readAll().toArray();
    * ```
    */
-  public readAll(options?: FeedOptions): QueryIterator<StoredProcedureDefinition> {
-    return this.query(undefined, options);
+  public readAll(options?: FeedOptions): QueryIterator<StoredProcedureDefinition & Resource> {
+    return this.query<StoredProcedureDefinition & Resource>(undefined, options);
   }
 
   /**
@@ -79,7 +96,14 @@ export class StoredProcedures {
     const path = Helper.getPathFromLink(this.container.url, "sprocs");
     const id = Helper.getIdFromLink(this.container.url);
 
-    const response = await this.clientContext.create(body, path, "sprocs", id, undefined, options);
+    const response = await this.clientContext.create<StoredProcedureDefinition>(
+      body,
+      path,
+      "sprocs",
+      id,
+      undefined,
+      options
+    );
     const ref = new StoredProcedure(this.container, response.result.id, this.clientContext);
     return { body: response.result, headers: response.headers, ref, storedProcedure: ref, sproc: ref };
   }
@@ -107,7 +131,14 @@ export class StoredProcedures {
     const path = Helper.getPathFromLink(this.container.url, "sprocs");
     const id = Helper.getIdFromLink(this.container.url);
 
-    const response = await this.clientContext.upsert(body, path, "sprocs", id, undefined, options);
+    const response = await this.clientContext.upsert<StoredProcedureDefinition>(
+      body,
+      path,
+      "sprocs",
+      id,
+      undefined,
+      options
+    );
     const ref = new StoredProcedure(this.container, response.result.id, this.clientContext);
     return { body: response.result, headers: response.headers, ref, storedProcedure: ref, sproc: ref };
   }

--- a/src/client/Trigger/Trigger.ts
+++ b/src/client/Trigger/Trigger.ts
@@ -1,7 +1,7 @@
 import { ClientContext } from "../../ClientContext";
 import { Helper, UriFactory } from "../../common";
 import { CosmosClient } from "../../CosmosClient";
-import { RequestOptions, Response } from "../../request";
+import { RequestOptions } from "../../request";
 import { Container } from "../Container";
 import { TriggerDefinition } from "./TriggerDefinition";
 import { TriggerResponse } from "./TriggerResponse";
@@ -84,9 +84,7 @@ export class Trigger {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = (await this.clientContext.delete(path, "triggers", id, undefined, options)) as Response<
-      TriggerDefinition
-    >; // TODO: casting
+    const response = await this.clientContext.delete<TriggerDefinition>(path, "triggers", id, undefined, options);
 
     return { body: response.result, headers: response.headers, ref: this, trigger: this };
   }

--- a/src/client/Trigger/TriggerResponse.ts
+++ b/src/client/Trigger/TriggerResponse.ts
@@ -1,8 +1,9 @@
 import { Trigger } from ".";
 import { CosmosResponse } from "../../request";
+import { Resource } from "../Resource";
 import { TriggerDefinition } from "./TriggerDefinition";
 
-export interface TriggerResponse extends CosmosResponse<TriggerDefinition, Trigger> {
+export interface TriggerResponse extends CosmosResponse<TriggerDefinition & Resource, Trigger> {
   /** A reference to the {@link Trigger} corresponding to the returned {@link TriggerDefinition}. */
   trigger: Trigger;
 }

--- a/src/client/Trigger/Triggers.ts
+++ b/src/client/Trigger/Triggers.ts
@@ -1,10 +1,10 @@
 import { ClientContext } from "../../ClientContext";
 import { Helper } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
 import { FeedOptions, RequestOptions } from "../../request";
 import { Container } from "../Container";
+import { Resource } from "../Resource";
 import { Trigger } from "./Trigger";
 import { TriggerDefinition } from "./TriggerDefinition";
 import { TriggerResponse } from "./TriggerResponse";
@@ -15,21 +15,25 @@ import { TriggerResponse } from "./TriggerResponse";
  * Use `container.triggers` to read, replace, or delete a {@link Trigger}.
  */
 export class Triggers {
-  private client: CosmosClient;
   /**
    * @hidden
    * @param container The parent {@link Container}.
    */
-  constructor(public readonly container: Container, private readonly clientContext: ClientContext) {
-    this.client = this.container.database.client;
-  }
+  constructor(public readonly container: Container, private readonly clientContext: ClientContext) {}
 
   /**
    * Query all Triggers.
    * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    * @param options
    */
-  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<TriggerDefinition> {
+  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
+  /**
+   * Query all Triggers.
+   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options
+   */
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
     const path = Helper.getPathFromLink(this.container.url, "triggers");
     const id = Helper.getIdFromLink(this.container.url);
 
@@ -46,8 +50,8 @@ export class Triggers {
    * const {body: triggerList} = await container.triggers.readAll().toArray();
    * ```
    */
-  public readAll(options?: FeedOptions): QueryIterator<TriggerDefinition> {
-    return this.query(undefined, options);
+  public readAll(options?: FeedOptions): QueryIterator<TriggerDefinition & Resource> {
+    return this.query<TriggerDefinition & Resource>(undefined, options);
   }
   /**
    * Create a trigger.
@@ -72,7 +76,7 @@ export class Triggers {
     const path = Helper.getPathFromLink(this.container.url, "triggers");
     const id = Helper.getIdFromLink(this.container.url);
 
-    const response = await this.clientContext.create(body, path, "triggers", id, undefined, options);
+    const response = await this.clientContext.create<TriggerDefinition>(body, path, "triggers", id, undefined, options);
     const ref = new Trigger(this.container, response.result.id, this.clientContext);
     return { body: response.result, headers: response.headers, ref, trigger: ref };
   }
@@ -100,7 +104,7 @@ export class Triggers {
     const path = Helper.getPathFromLink(this.container.url, "triggers");
     const id = Helper.getIdFromLink(this.container.url);
 
-    const response = await this.clientContext.upsert(body, path, "triggers", id, undefined, options);
+    const response = await this.clientContext.upsert<TriggerDefinition>(body, path, "triggers", id, undefined, options);
     const ref = new Trigger(this.container, response.result.id, this.clientContext);
     return { body: response.result, headers: response.headers, ref, trigger: ref };
   }

--- a/src/client/User/User.ts
+++ b/src/client/User/User.ts
@@ -1,6 +1,5 @@
 import { ClientContext } from "../../ClientContext";
 import { Helper, UriFactory } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions } from "../../request";
 import { Database } from "../Database";
 import { Permission, Permissions } from "../Permission";
@@ -27,7 +26,6 @@ export class User {
   public get url() {
     return UriFactory.createUserUri(this.database.id, this.id);
   }
-  private client: CosmosClient;
   /**
    * @hidden
    * @param database The parent {@link Database}.
@@ -38,7 +36,6 @@ export class User {
     public readonly id: string,
     private readonly clientContext: ClientContext
   ) {
-    this.client = this.database.client;
     this.permissions = new Permissions(this, this.clientContext);
   }
 
@@ -59,7 +56,7 @@ export class User {
   public async read(options?: RequestOptions): Promise<UserResponse> {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
-    const response = await this.clientContext.read(path, "users", id, undefined, options);
+    const response = await this.clientContext.read<UserDefinition>(path, "users", id, undefined, options);
     return { body: response.result, headers: response.headers, ref: this, user: this };
   }
 
@@ -77,7 +74,7 @@ export class User {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.replace(body, path, "users", id, undefined, options);
+    const response = await this.clientContext.replace<UserDefinition>(body, path, "users", id, undefined, options);
     return { body: response.result, headers: response.headers, ref: this, user: this };
   }
 
@@ -89,7 +86,7 @@ export class User {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.delete(path, "users", id, undefined, options);
+    const response = await this.clientContext.delete<UserDefinition>(path, "users", id, undefined, options);
     return { body: response.result, headers: response.headers, ref: this, user: this };
   }
 }

--- a/src/client/User/UserResponse.ts
+++ b/src/client/User/UserResponse.ts
@@ -1,8 +1,9 @@
 import { CosmosResponse } from "../../request";
+import { Resource } from "../Resource";
 import { User } from "./User";
 import { UserDefinition } from "./UserDefinition";
 
-export interface UserResponse extends CosmosResponse<UserDefinition, User> {
+export interface UserResponse extends CosmosResponse<UserDefinition & Resource, User> {
   /** A reference to the {@link User} corresponding to the returned {@link UserDefinition}. */
   user: User;
 }

--- a/src/client/UserDefinedFunction/UserDefinedFunction.ts
+++ b/src/client/UserDefinedFunction/UserDefinedFunction.ts
@@ -1,6 +1,5 @@
 import { ClientContext } from "../../ClientContext";
 import { Helper, UriFactory } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
 import { RequestOptions } from "../../request";
 import { Container } from "../Container";
 import { UserDefinedFunctionDefinition } from "./UserDefinedFunctionDefinition";
@@ -18,7 +17,6 @@ export class UserDefinedFunction {
   public get url() {
     return UriFactory.createUserDefinedFunctionUri(this.container.database.id, this.container.id, this.id);
   }
-  private client: CosmosClient;
   /**
    * @hidden
    * @param container The parent {@link Container}.
@@ -28,9 +26,7 @@ export class UserDefinedFunction {
     public readonly container: Container,
     public readonly id: string,
     private readonly clientContext: ClientContext
-  ) {
-    this.client = this.container.database.client;
-  }
+  ) {}
 
   /**
    * Read the {@link UserDefinedFunctionDefinition} for the given {@link UserDefinedFunction}.
@@ -40,7 +36,7 @@ export class UserDefinedFunction {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.read(path, "udfs", id, undefined, options);
+    const response = await this.clientContext.read<UserDefinedFunctionDefinition>(path, "udfs", id, undefined, options);
     return { body: response.result, headers: response.headers, ref: this, userDefinedFunction: this, udf: this };
   }
 
@@ -65,7 +61,14 @@ export class UserDefinedFunction {
     const path = Helper.getPathFromLink(this.url);
     const id = Helper.getIdFromLink(this.url);
 
-    const response = await this.clientContext.replace(body, path, "udfs", id, undefined, options);
+    const response = await this.clientContext.replace<UserDefinedFunctionDefinition>(
+      body,
+      path,
+      "udfs",
+      id,
+      undefined,
+      options
+    );
     return { body: response.result, headers: response.headers, ref: this, userDefinedFunction: this, udf: this };
   }
 

--- a/src/client/UserDefinedFunction/UserDefinedFunctionResponse.ts
+++ b/src/client/UserDefinedFunction/UserDefinedFunctionResponse.ts
@@ -1,9 +1,10 @@
 import { CosmosResponse } from "../../request";
+import { Resource } from "../Resource";
 import { UserDefinedFunction } from "./UserDefinedFunction";
 import { UserDefinedFunctionDefinition } from "./UserDefinedFunctionDefinition";
 
 export interface UserDefinedFunctionResponse
-  extends CosmosResponse<UserDefinedFunctionDefinition, UserDefinedFunction> {
+  extends CosmosResponse<UserDefinedFunctionDefinition & Resource, UserDefinedFunction> {
   /** A reference to the {@link UserDefinedFunction} corresponding to the returned {@link UserDefinedFunctionDefinition}. */
   userDefinedFunction: UserDefinedFunction;
   /**

--- a/src/client/UserDefinedFunction/UserDefinedFunctions.ts
+++ b/src/client/UserDefinedFunction/UserDefinedFunctions.ts
@@ -1,10 +1,10 @@
 import { ClientContext } from "../../ClientContext";
 import { Helper } from "../../common";
-import { CosmosClient } from "../../CosmosClient";
 import { SqlQuerySpec } from "../../queryExecutionContext";
 import { QueryIterator } from "../../queryIterator";
-import { FeedOptions, RequestOptions, Response } from "../../request";
+import { FeedOptions, RequestOptions } from "../../request";
 import { Container } from "../Container";
+import { Resource } from "../Resource";
 import { UserDefinedFunction } from "./UserDefinedFunction";
 import { UserDefinedFunctionDefinition } from "./UserDefinedFunctionDefinition";
 import { UserDefinedFunctionResponse } from "./UserDefinedFunctionResponse";
@@ -15,21 +15,25 @@ import { UserDefinedFunctionResponse } from "./UserDefinedFunctionResponse";
  * @see {@link UserDefinedFunction} to read, replace, or delete a given User Defined Function by id.
  */
 export class UserDefinedFunctions {
-  private client: CosmosClient;
   /**
    * @hidden
    * @param container The parent {@link Container}.
    */
-  constructor(public readonly container: Container, private readonly clientContext: ClientContext) {
-    this.client = this.container.database.client;
-  }
+  constructor(public readonly container: Container, private readonly clientContext: ClientContext) {}
 
   /**
    * Query all User Defined Functions.
    * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
    * @param options
    */
-  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<UserDefinedFunctionDefinition> {
+  public query(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<any>;
+  /**
+   * Query all User Defined Functions.
+   * @param query Query configuration for the operation. See {@link SqlQuerySpec} for more info on how to configure a query.
+   * @param options
+   */
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T>;
+  public query<T>(query: SqlQuerySpec, options?: FeedOptions): QueryIterator<T> {
     const path = Helper.getPathFromLink(this.container.url, "udfs");
     const id = Helper.getIdFromLink(this.container.url);
 
@@ -46,8 +50,8 @@ export class UserDefinedFunctions {
    * const {body: udfList} = await container.userDefinedFunctions.readAll().toArray();
    * ```
    */
-  public readAll(options?: FeedOptions): QueryIterator<UserDefinedFunctionDefinition> {
-    return this.query(undefined, options);
+  public readAll(options?: FeedOptions): QueryIterator<UserDefinedFunctionDefinition & Resource> {
+    return this.query<UserDefinedFunctionDefinition & Resource>(undefined, options);
   }
 
   /**
@@ -74,7 +78,14 @@ export class UserDefinedFunctions {
     const path = Helper.getPathFromLink(this.container.url, "udfs");
     const id = Helper.getIdFromLink(this.container.url);
 
-    const response = await this.clientContext.create(body, path, "udfs", id, undefined, options);
+    const response = await this.clientContext.create<UserDefinedFunctionDefinition>(
+      body,
+      path,
+      "udfs",
+      id,
+      undefined,
+      options
+    );
     const ref = new UserDefinedFunction(this.container, response.result.id, this.clientContext);
     return { body: response.result, headers: response.headers, ref, userDefinedFunction: ref, udf: ref };
   }
@@ -103,7 +114,14 @@ export class UserDefinedFunctions {
     const path = Helper.getPathFromLink(this.container.url, "udfs");
     const id = Helper.getIdFromLink(this.container.url);
 
-    const response = await this.clientContext.upsert(body, path, "udfs", id, undefined, options);
+    const response = await this.clientContext.upsert<UserDefinedFunctionDefinition>(
+      body,
+      path,
+      "udfs",
+      id,
+      undefined,
+      options
+    );
     const ref = new UserDefinedFunction(this.container, response.result.id, this.clientContext);
     return { body: response.result, headers: response.headers, ref, userDefinedFunction: ref, udf: ref };
   }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -8,3 +8,4 @@ export * from "./StoredProcedure";
 export * from "./Trigger";
 export * from "./User";
 export * from "./UserDefinedFunction";
+export * from "./Resource";

--- a/src/test/common/TestHelpers.ts
+++ b/src/test/common/TestHelpers.ts
@@ -5,11 +5,11 @@ import {
   ItemDefinition,
   ItemResponse,
   PermissionResponse,
+  Resource,
   TriggerResponse,
   User,
   UserDefinedFunctionResponse
 } from "../../client";
-import { ItemBody } from "../../client/Item/ItemBody";
 import { StoredProcedureResponse } from "../../client/StoredProcedure/StoredProcedureResponse";
 import { UserResponse } from "../../client/User/UserResponse";
 import { endpoint, masterKey } from "./_testConfig";
@@ -70,7 +70,7 @@ export async function getTestContainer(
 export async function bulkInsertItems(
   container: Container,
   documents: any[]
-): Promise<Array<ItemDefinition & ItemBody>> {
+): Promise<Array<ItemDefinition & Resource>> {
   const returnedDocuments = [];
   for (const doc of documents) {
     try {

--- a/src/test/functional/item.spec.ts
+++ b/src/test/functional/item.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import { Container, DocumentBase } from "../..";
+import { ItemDefinition } from "../../client";
 import {
   bulkDeleteItems,
   bulkInsertItems,
@@ -163,7 +164,7 @@ describe("NodeJS CRUD Tests", function() {
         assert.equal(err.code, badRequestErrorCode, "response should return error code " + badRequestErrorCode);
       }
       const { result: results } = await container.items
-        .query(querySpec, { enableScanInQuery: true, enableCrossPartitionQuery: true })
+        .query<ItemDefinition>(querySpec, { enableScanInQuery: true, enableCrossPartitionQuery: true })
         .toArray();
       assert(results !== undefined, "error querying documents");
       results.sort(function(doc1, doc2) {


### PR DESCRIPTION
* Gets rid of ItemBody
* Adds Resource to all response types
* Updates ClientContext to add Resource to all CRUD ops
* Allows upsert/create to pass a second type to union to the response
* Updates query to return T or any, not <ResourceType>Definition