### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/admin.ps1
+++ b/admin.ps1
@@ -1,0 +1,1 @@
+  Start-Process powershell -ArgumentList '-noprofile -file test.ps1' -verb RunAs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,10 @@
+pool:
+  vmImage: "vs2017-win2016"
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: "10.x"
+  - script: |
+      powershell ./admin.ps1
+      npm ci && npm run build && npm run test && npm run test-ts && npm run test-browser

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,2 @@
+Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+Start-CosmosDbEmulator


### PR DESCRIPTION
The new CI job runs all the tests (in the browser as well) in Azure Pipelines, once https://github.com/Microsoft/azure-pipelines-image-generation/ is updated with the new emulator and it's deployed to Azure Pipelines.
This PR passed (most of) the tests before rebasing to the 2.0.0 GA release