### PR TITLE
Retry interface implementation must exactly match

### DIFF
--- a/src/retry/endpointDiscoveryRetryPolicy.ts
+++ b/src/retry/endpointDiscoveryRetryPolicy.ts
@@ -36,10 +36,14 @@ export class EndpointDiscoveryRetryPolicy implements IRetryPolicy {
    */
   public async shouldRetry(
     err: ErrorResponse,
-    retryContext: RetryContext,
-    locationEndpoint: string
+    retryContext?: RetryContext,
+    locationEndpoint?: string
   ): Promise<boolean | [boolean, string]> {
     if (!err) {
+      return false;
+    }
+
+    if (!retryContext || !locationEndpoint) {
       return false;
     }
 

--- a/src/retry/sessionRetryPolicy.ts
+++ b/src/retry/sessionRetryPolicy.ts
@@ -34,8 +34,12 @@ export class SessionRetryPolicy implements IRetryPolicy {
    * @param {function} callback - The callback function which takes bool argument which specifies whether the request\
    * will be retried or not.
    */
-  public async shouldRetry(err: ErrorResponse, retryContext: RetryContext): Promise<boolean> {
+  public async shouldRetry(err: ErrorResponse, retryContext?: RetryContext): Promise<boolean> {
     if (!err) {
+      return false;
+    }
+
+    if (!retryContext) {
       return false;
     }
 


### PR DESCRIPTION
fixes #141

See #141 for the issue. Basically, TypeScript apparently has some weird bugs where you can build that in your own code base, but not somewhere else? Really unfortunate behavior. I think we need to set up some CI that uses our package via `npm pack`. CI didn't catch this issue.