### PR TITLE
chore: Match EditorConfig match Prettier TS file rule

### DIFF
--- a/.editorConfig
+++ b/.editorConfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.ts]
+indent_size = 2


### PR DESCRIPTION
Noticed in #162 that the EditorConfg and Prettier settings were conflicting, so the IDE was re-indenting TS files that Prettier would then flag in the build