### PR TITLE
Mirror node Agent interface. Prevents leaking of node types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/cosmos",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/CosmosClientOptions.ts
+++ b/src/CosmosClientOptions.ts
@@ -1,7 +1,15 @@
-import { Agent } from "http";
 import { AuthOptions } from "./auth";
 import { ConnectionPolicy, ConsistencyLevel, QueryCompatibilityMode } from "./documents";
 import { IHeaders } from "./queryExecutionContext/IHeaders";
+
+// We expose our own Agent interface to avoid taking a dependency on and leaking node types. This interface should mirror the node Agent interface
+interface Agent {
+  maxFreeSockets: number;
+  maxSockets: number;
+  sockets: any;
+  requests: any;
+  destroy(): void;
+}
 
 export interface CosmosClientOptions {
   /** The service endpoint to use to create the client. */

--- a/src/test/functional/client.spec.ts
+++ b/src/test/functional/client.spec.ts
@@ -4,7 +4,7 @@ import { CosmosClient, DocumentBase } from "../..";
 import { endpoint, masterKey } from "../common/_testConfig";
 import { getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
 
-describe.only("NodeJS CRUD Tests", function() {
+describe("NodeJS CRUD Tests", function() {
   this.timeout(process.env.MOCHA_TIMEOUT || 20000);
 
   describe("Validate client request timeout", function() {

--- a/src/test/functional/client.spec.ts
+++ b/src/test/functional/client.spec.ts
@@ -1,12 +1,12 @@
 import assert from "assert";
+import { Agent } from "http";
 import { CosmosClient, DocumentBase } from "../..";
 import { endpoint, masterKey } from "../common/_testConfig";
 import { getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
 
-describe("NodeJS CRUD Tests", function() {
+describe.only("NodeJS CRUD Tests", function() {
   this.timeout(process.env.MOCHA_TIMEOUT || 20000);
 
-  // TODO: disabled tests need to get fixed or deleted
   describe("Validate client request timeout", function() {
     it("nativeApi Client Should throw exception", async function() {
       const connectionPolicy = new DocumentBase.ConnectionPolicy();
@@ -32,6 +32,15 @@ describe("NodeJS CRUD Tests", function() {
         connectionPolicy: {
           RequestTimeout: 10000
         }
+      });
+      assert.ok(client !== undefined, "client shouldn't be undefined if it succeeded");
+    });
+
+    it("Accepts node Agent", function() {
+      const client = new CosmosClient({
+        endpoint: "https://faaaaaake.com",
+        auth: { masterKey: "" },
+        agent: new Agent()
       });
       assert.ok(client !== undefined, "client shouldn't be undefined if it succeeded");
     });


### PR DESCRIPTION
Confirmed using https://github.com/Microsoft/web-build-tools/wiki/API-Extractor that this change no longer emits a reference to node types 🎉 