### PR TITLE
QueryIterator.Next now returns the next item properly for single partition queries

### DIFF
--- a/src/queryExecutionContext/defaultQueryExecutionContext.ts
+++ b/src/queryExecutionContext/defaultQueryExecutionContext.ts
@@ -60,8 +60,8 @@ export class DefaultQueryExecutionContext implements IExecutionContext {
    * @instance
    */
   public async nextItem(): Promise<Response<any>> {
-    const response = await this.current();
     ++this.currentIndex;
+    const response = await this.current();
     return response;
   }
 
@@ -112,7 +112,7 @@ export class DefaultQueryExecutionContext implements IExecutionContext {
     return (
       this.state === DefaultQueryExecutionContext.STATES.start ||
       this.continuation !== undefined ||
-      this.currentIndex < this.resources.length ||
+      this.currentIndex < this.resources.length - 1 ||
       this.currentPartitionIndex < this.fetchFunctions.length
     );
   }

--- a/src/test/functional/query.spec.ts
+++ b/src/test/functional/query.spec.ts
@@ -90,7 +90,10 @@ describe("NodeJS CRUD Tests", function() {
       const queryIterator = container.items.readAll();
       let cnt = 0;
       while (queryIterator.hasMoreResults()) {
-        await queryIterator.nextItem();
+        const { result } = await queryIterator.nextItem();
+        if (result === undefined) {
+          break;
+        }
         cnt++;
       }
       assert.equal(cnt, documentDefinitions.length);
@@ -152,20 +155,20 @@ describe("NodeJS CRUD Tests", function() {
     const queryIteratorNextAndMoreTest = async function() {
       const queryIterator = resources.container.items.readAll({ maxItemCount: 2 });
       assert.equal(queryIterator.hasMoreResults(), true);
-      const { result: doc1 } = await queryIterator.current();
-      assert.equal(doc1.id, resources.doc1.id, "call queryIterator.current after reset should return first document");
       const { result: doc2 } = await queryIterator.nextItem();
       assert.equal(doc2.id, resources.doc1.id, "call queryIterator.nextItem after reset should return first document");
+      const { result: doc1 } = await queryIterator.current();
+      assert.equal(doc1.id, resources.doc1.id, "call queryIterator.current after reset should return first document");
       assert.equal(queryIterator.hasMoreResults(), true);
-      const { result: doc3 } = await queryIterator.current();
-      assert.equal(doc3.id, resources.doc2.id, "call queryIterator.current should return second document");
       const { result: doc4 } = await queryIterator.nextItem();
       assert.equal(doc4.id, resources.doc2.id, "call queryIterator.nextItem again should return second document");
+      const { result: doc3 } = await queryIterator.current();
+      assert.equal(doc3.id, resources.doc2.id, "call queryIterator.current should return second document");
       assert.equal(queryIterator.hasMoreResults(), true);
-      const { result: doc5 } = await queryIterator.current();
-      assert.equal(doc5.id, resources.doc3.id, "call queryIterator.current should return third document");
       const { result: doc6 } = await queryIterator.nextItem();
       assert.equal(doc6.id, resources.doc3.id, "call queryIterator.nextItem again should return third document");
+      const { result: doc5 } = await queryIterator.current();
+      assert.equal(doc5.id, resources.doc3.id, "call queryIterator.current should return third document");
       const { result: doc7 } = await queryIterator.nextItem();
       assert.equal(doc7, undefined, "queryIterator should return undefined if there is no elements");
     };

--- a/src/test/integration/query.spec.ts
+++ b/src/test/integration/query.spec.ts
@@ -41,6 +41,7 @@ describe("ResourceLink Trimming of leading and trailing slashes", function() {
 });
 
 describe("Test Query Metrics On Single Partition Collection", function() {
+  this.timeout(process.env.MOCHA_TIMEOUT || 20000);
   const collectionId = "testCollection2";
 
   const testQueryMetricsOnSinglePartition = async function(document: any) {


### PR DESCRIPTION
FYI - This is a breaking change, but the previous behavior was a bug.

See #185 for details of the next bug.

Also enables aggregate tests again, which is where I caught this issue.