### PR TITLE
Fix path building

### DIFF
--- a/src/ClientContext.ts
+++ b/src/ClientContext.ts
@@ -142,8 +142,6 @@ export class ClientContext {
       );
       this.applySessionToken(path, reqHeaders);
 
-      console.log(endpoint);
-
       const response = await this.requestHandler.post(endpoint, request, query, reqHeaders);
       const { result, headers: resHeaders } = response;
       this.captureSessionToken(undefined, path, Constants.OperationTypes.Query, resHeaders);

--- a/src/ClientContext.ts
+++ b/src/ClientContext.ts
@@ -142,6 +142,8 @@ export class ClientContext {
       );
       this.applySessionToken(path, reqHeaders);
 
+      console.log(endpoint);
+
       const response = await this.requestHandler.post(endpoint, request, query, reqHeaders);
       const { result, headers: resHeaders } = response;
       this.captureSessionToken(undefined, path, Constants.OperationTypes.Query, resHeaders);

--- a/src/request/RequestHandler.ts
+++ b/src/request/RequestHandler.ts
@@ -49,7 +49,7 @@ export class RequestHandler {
     headers: IHeaders
   ): Promise<Response<any>> {
     // TODO: any
-    const path = (request as { path: string }).path === undefined ? request : (request as { path: string }).path;
+    const path = request.path;
     let body: any; // TODO: any
 
     if (data) {
@@ -85,8 +85,13 @@ export class RequestHandler {
     }
 
     const requestOptions: RequestOptions = parse(hostname);
+
     requestOptions.method = method;
-    requestOptions.path += path;
+    if (requestOptions.path && requestOptions.path !== "/") {
+      requestOptions.path += path;
+    } else {
+      requestOptions.path = path;
+    }
     requestOptions.headers = headers as OutgoingHttpHeaders;
     requestOptions.agent = requestAgent;
     requestOptions.secureProtocol = "TLSv1_client_method"; // TODO: Should be a constant
@@ -132,6 +137,7 @@ export class RequestHandler {
 
   /** @ignore */
   public get(urlString: string, request: RequestContext, headers: IHeaders) {
+    console.log(request);
     // TODO: any
     return RequestHandler.request(
       this.globalEndpointManager,

--- a/src/request/RequestHandler.ts
+++ b/src/request/RequestHandler.ts
@@ -137,7 +137,6 @@ export class RequestHandler {
 
   /** @ignore */
   public get(urlString: string, request: RequestContext, headers: IHeaders) {
-    console.log(request);
     // TODO: any
     return RequestHandler.request(
       this.globalEndpointManager,


### PR DESCRIPTION
The request path building logic is sensitive to the format of the `endpoint` config option. This is the current behavior on master:

``` js
const client = new CosmosClient({
  endpoint: "https://endpoint.com"
});
client.offers.readAll().toArray()
// GET /offers
```

This case works somehow. Maybe node is smart enough to deal with the double slash?

``` js
const client = new CosmosClient({
  endpoint: "https://endpoint.com/"
});
client.offers.readAll().toArray()
// GET //offers
```

Passing an invalid URL to endpoint is broken on master:

``` js
const client = new CosmosClient({
  endpoint: " "
});
client.offers.readAll().toArray()
// GET /null/offers
```

This PR makes it so all three cases resolve to GET /offers
