### PR TITLE
Add "key" property (instead of just masterKey)

### DIFF
--- a/src/CosmosClient.ts
+++ b/src/CosmosClient.ts
@@ -56,6 +56,9 @@ export class CosmosClient {
   private clientContext: ClientContext;
   constructor(private options: CosmosClientOptions) {
     options.auth = options.auth || {};
+    if (options.key) {
+      options.auth.key = options.key;
+    }
 
     options.connectionPolicy = Helper.parseConnectionPolicy(options.connectionPolicy);
 

--- a/src/CosmosClientOptions.ts
+++ b/src/CosmosClientOptions.ts
@@ -14,8 +14,10 @@ interface Agent {
 export interface CosmosClientOptions {
   /** The service endpoint to use to create the client. */
   endpoint: string;
+  /** The account master or readonly key (alias of auth.key) */
+  key?: string;
   /** An object that is used for authenticating requests and must contains one of the options */
-  auth: AuthOptions;
+  auth?: AuthOptions;
   /** An instance of {@link ConnectionPolicy} class.
    * This parameter is optional and the default connectionPolicy will be used if omitted.
    */

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -18,6 +18,8 @@ export interface ITokenProvider {
 }
 
 export interface AuthOptions {
+  /** Account master key or read only key */
+  key?: string;
   /** The authorization master key to use to create the client. */
   masterKey?: string;
   /** An object that contains resources tokens.
@@ -52,9 +54,10 @@ export class AuthHandler {
       }
     }
 
-    if (authOptions.masterKey) {
+    if (authOptions.masterKey || authOptions.key) {
+      const key = authOptions.masterKey || authOptions.key;
       return encodeURIComponent(
-        AuthHandler.getAuthorizationTokenUsingMasterKey(verb, resourceId, resourceType, headers, authOptions.masterKey)
+        AuthHandler.getAuthorizationTokenUsingMasterKey(verb, resourceId, resourceType, headers, key)
       );
     } else if (authOptions.resourceTokens) {
       return encodeURIComponent(

--- a/src/request/request.ts
+++ b/src/request/request.ts
@@ -264,7 +264,7 @@ export async function getHeaders(
     headers[Constants.HttpHeaders.PartitionKey] = Helper.jsonStringifyAndEscapeNonASCII(partitionKey);
   }
 
-  if (authOptions.masterKey || authOptions.tokenProvider) {
+  if (authOptions.masterKey || authOptions.key || authOptions.tokenProvider) {
     headers[Constants.HttpHeaders.XDate] = new Date().toUTCString();
   }
 
@@ -293,7 +293,13 @@ export async function getHeaders(
   if (opts.disableRUPerMinuteUsage) {
     headers[Constants.HttpHeaders.DisableRUPerMinuteUsage] = true;
   }
-  if (authOptions.masterKey || authOptions.resourceTokens || authOptions.tokenProvider || authOptions.permissionFeed) {
+  if (
+    authOptions.masterKey ||
+    authOptions.key ||
+    authOptions.resourceTokens ||
+    authOptions.tokenProvider ||
+    authOptions.permissionFeed
+  ) {
     const token = await AuthHandler.getAuthorizationHeader(authOptions, verb, path, resourceId, resourceType, headers);
     headers[Constants.HttpHeaders.Authorization] = token;
   }

--- a/src/test/functional/authorization.spec.ts
+++ b/src/test/functional/authorization.spec.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { CosmosClient, DocumentBase } from "../..";
 import { PermissionDefinition } from "../../client";
-import { endpoint } from "../common/_testConfig";
+import { endpoint, masterKey } from "../common/_testConfig";
 import { createOrUpsertPermission, getTestContainer, getTestDatabase, removeAllDatabases } from "../common/TestHelpers";
 
 describe("NodeJS CRUD Tests", function() {
@@ -11,6 +11,26 @@ describe("NodeJS CRUD Tests", function() {
   });
 
   describe("Validate Authorization", function() {
+    it("should handle all the key options", async function() {
+      const clientOptionsKey = new CosmosClient({ endpoint, key: masterKey });
+      assert(
+        undefined !== (await clientOptionsKey.databases.readAll().toArray()),
+        "Should be able to fetch list of databases"
+      );
+
+      const clientOptionsAuthKey = new CosmosClient({ endpoint, auth: { key: masterKey } });
+      assert(
+        undefined !== (await clientOptionsAuthKey.databases.readAll().toArray()),
+        "Should be able to fetch list of databases"
+      );
+
+      const clientOptionsAuthMasterKey = new CosmosClient({ endpoint, auth: { masterKey } });
+      assert(
+        undefined !== (await clientOptionsAuthMasterKey.databases.readAll().toArray()),
+        "Should be able to fetch list of databases"
+      );
+    });
+
     const setupEntities = async function(isUpsertTest: boolean) {
       // create database
       const database = await getTestDatabase("Validate Authorization database");


### PR DESCRIPTION
Adds:
 - `key` property to AuthOptions (since masterKey and readOnly key both work)
 - `key` property to CosmosClientOptions as an alias of the auth.key property
 - test coverage for all three options