### PR TITLE
Demo and demo debugging fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,6 +34,7 @@
       "request": "launch",
       "name": "Debug file",
       "program": "${file}",
+      "cwd": "${fileDirname}",
       "env": {
         "NODE_TLS_REJECT_UNAUTHORIZED": "0"
       }

--- a/samples/ChangeFeed/app.js
+++ b/samples/ChangeFeed/app.js
@@ -141,8 +141,8 @@ async function init() {
 }
 
 async function handleError(error) {
-  console.log("\nAn error with code '" + error.code + "' has occurred:");
-  console.log("\t" + error);
+  console.log(`\nAn error with code '${error.code}' has occurred:`);
+  console.log(`\t${error}`);
 }
 
 async function finish(container) {

--- a/samples/ChangeFeed/app.js
+++ b/samples/ChangeFeed/app.js
@@ -1,7 +1,7 @@
 ﻿// @ts-check
 "use strict";
 
-const cosmos = require("../../lib/");
+const cosmos = require("../../lib/src");
 const CosmosClient = cosmos.CosmosClient;
 const config = require("../Shared/config");
 const databaseId = config.names.database;

--- a/samples/ContainerManagement/app.js
+++ b/samples/ContainerManagement/app.js
@@ -33,7 +33,7 @@ async function run() {
   const database = await init(databaseId);
 
   //1.
-  console.log("1. create container with id '" + containerId + "'");
+  console.log(`1. create container with id '${containerId}'`);
   await database.containers.createIfNotExists({ id: containerId });
 
   //2.
@@ -48,10 +48,10 @@ async function run() {
   const container = database.container(containerId);
   const { body: containerDef } = await container.read();
 
-  console.log("container with url '" + container.url + "' was found its id is '" + containerDef.id);
+  console.log(`container with url '${container.url}' was found its id is '${containerDef.id}'`);
 
   //4.
-  console.log("\n4. deletecontainer '" + containerId + "'");
+  console.log(`\n4. deletecontainer '${containerId}'`);
   await container.delete();
   await finish(database);
 }
@@ -62,7 +62,7 @@ async function init(databaseId) {
 }
 
 async function handleError(error) {
-  console.log("\nAn error with code '" + error.code + "' has occurred:");
+  console.log(`\nAn error with code '${error.code}' has occurred:`);
   console.log("\t" + error);
 
   await finish();

--- a/samples/ContainerManagement/app.js
+++ b/samples/ContainerManagement/app.js
@@ -8,7 +8,7 @@ console.log("container MANAGEMENT");
 console.log("=====================");
 console.log();
 
-const cosmos = require("../../lib/");
+const cosmos = require("../../lib/src");
 const CosmosClient = cosmos.CosmosClient;
 const config = require("../Shared/config");
 const databaseId = config.names.database;

--- a/samples/DatabaseManagement/app.js
+++ b/samples/DatabaseManagement/app.js
@@ -9,7 +9,7 @@ console.log("===================");
 console.log();
 
 const assert = require("assert");
-const cosmos = require("../../lib/");
+const cosmos = require("../../lib/src");
 const CosmosClient = cosmos.CosmosClient;
 const config = require("../Shared/config");
 const databaseId = config.names.database;

--- a/samples/DatabaseManagement/app.js
+++ b/samples/DatabaseManagement/app.js
@@ -32,7 +32,7 @@ const client = new CosmosClient({ endpoint, auth: { masterKey } });
 
 async function run() {
   // 1.
-  console.log("\n1. Create database, if it doesn't already exist '" + databaseId + "'");
+  console.log(`\n1. Create database, if it doesn't already exist '${databaseId}'`);
   await client.databases.createIfNotExists({ id: databaseId });
   console.log("Database with id " + databaseId + " created.");
 
@@ -42,7 +42,7 @@ async function run() {
   console.log(dbDefList);
 
   // 3.
-  console.log("\n3. readDatabase - with id '" + databaseId + "'");
+  console.log(`\n3. readDatabase - with id '${databaseId}'`);
   const { body: dbDef } = await client.database(databaseId).read();
   // This uses Object deconstruction to just grab the body of the response,
   // but you can also grab the whole response object to use
@@ -51,10 +51,10 @@ async function run() {
   assert.equal(dbDef.id, alsoDbDef.id); // The bodies will also almost be equal, _ts will defer based on the read time
   // This applies for all response types, not just DatabaseResponse.
 
-  console.log("Database with id of " + dbDef.id + "' was found");
+  console.log(`Database with id of ${dbDef.id}' was found`);
 
   // 4.
-  console.log("\n4. delete database with id '" + databaseId + "'");
+  console.log(`\n4. delete database with id '${databaseId}'`);
   await client.database(databaseId).delete();
 
   await finish();
@@ -62,8 +62,8 @@ async function run() {
 
 function handleError(error) {
   console.log();
-  console.log("An error with code '" + error.code + "' has occurred:");
-  console.log("\t" + error.body || error);
+  console.log(`An error with code '${error.code}' has occurred:`);
+  console.log(`\t${error.body || error}`);
   console.log();
 
   finish();

--- a/samples/IndexManagement/app.js
+++ b/samples/IndexManagement/app.js
@@ -102,7 +102,7 @@ async function explictlyExcludeFromIndex(database) {
   //One of these options is indexingDirectives which can be include, or exclude
   //we're using exclude this time to manually exclude this item from being indexed
   const { body: itemDef, item } = await container.items.create(itemSpec, { indexingDirective: "exclude" });
-  console.log("Item with id '" + itemDef.id + "' created");
+  console.log(`Item with id '${itemDef.id}' created`);
 
   const querySpec = {
     query: "SELECT * FROM root r WHERE r.foo=@foo",
@@ -124,10 +124,10 @@ async function explictlyExcludeFromIndex(database) {
   console.log("item.read() should still find the item");
 
   const { body: readItemDef } = await item.read();
-  console.log("item.read() found item and its _self is '" + readItemDef._self + "'");
+  console.log(`item.read() found item and its _self is '${readItemDef._self}'`);
 
   await container.delete();
-  console.log("Container '" + containerId + "' deleted");
+  console.log(`Container '${containerId}' deleted`);
 }
 
 /**
@@ -541,7 +541,7 @@ async function waitForIndexTransformToComplete(container) {
 }
 
 async function handleError(error) {
-  console.log("\nAn error with code '" + error.code + "' has occurred:");
+  console.log(`\nAn error with code '${error.code}' has occurred:`);
   console.log("\t" + error.body || error);
 
   await finish();

--- a/samples/IndexManagement/app.js
+++ b/samples/IndexManagement/app.js
@@ -8,7 +8,7 @@ console.log("INDEX MANAGEMENT");
 console.log("================");
 console.log();
 
-const cosmos = require("../../lib/");
+const cosmos = require("../../lib/src");
 const CosmosClient = cosmos.CosmosClient;
 const config = require("../Shared/config");
 const fs = require("fs");
@@ -518,7 +518,7 @@ async function sleep(timeMS) {
  * To figure out the progress of and index transform,
   do a container read and check the header property of the response.
   The headers container includes a header that indicates progress between 0 and 100
- * @param {cosmos.Container} container 
+ * @param {cosmos.Container} container
  */
 async function waitForIndexTransformToComplete(container) {
   // To figure out the progress of and index transform,

--- a/samples/ItemManagement/app.js
+++ b/samples/ItemManagement/app.js
@@ -1,4 +1,4 @@
-﻿// @ts-check
+// @ts-check
 
 console.log();
 console.log("Azure Cosmos DB Node.js Samples");
@@ -46,7 +46,7 @@ async function run() {
   const { container, database } = await init();
 
   //1.
-  console.log("\n1. insert items in to database '" + databaseId + "' and container '" + containerId + "'");
+  console.log(`\n1. insert items in to database '${databaseId}' and container '${containerId}'`);
   const itemDefs = getItemDefinitions();
   const p = [];
   for (const itemDef of itemDefs) {
@@ -56,7 +56,7 @@ async function run() {
   console.log(itemDefs.length + " items created");
 
   //2.
-  console.log("\n2. list items in container '" + container.id + "'");
+  console.log(`\n2. list items in container '${container.id}'`);
   const { result: itemDefList } = await container.items.readAll().toArray();
 
   for (const itemDef of itemDefList) {
@@ -65,9 +65,9 @@ async function run() {
 
   //3.1
   const item = container.item(itemDefList[0].id);
-  console.log("\n3.1 read item '" + item.id + "'");
+  console.log(`\n3.1 read item '${item.id}'`);
   const { body: readDoc } = await item.read();
-  console.log("item with id '" + item.id + "' found");
+  console.log(`item with id '${item.id}' found`);
 
   //3.2
   console.log("\n3.2 read item with AccessCondition and no change to _etag");
@@ -104,7 +104,7 @@ async function run() {
     ]
   };
 
-  console.log("\n4. query items in container '" + container.id + "'");
+  console.log(`\n4. query items in container '${container.id}'`);
   const { result: results } = await container.items.query(querySpec).toArray();
 
   if (results.length == 0) {
@@ -114,8 +114,8 @@ async function run() {
   }
 
   const person = results[0];
-  console.log("The '" + person.id + "' family has lastName '" + person.lastName + "'");
-  console.log("The '" + person.id + "' family has " + person.children.length + " children '");
+  console.log(`The '${person.id}' family has lastName '${person.lastName}'`);
+  console.log(`The '${person.id}' family has ${person.children.length} children '`);
 
   //add a new child to this family, and change the family's lastName
   const childDef = {
@@ -129,11 +129,11 @@ async function run() {
   person.lastName = "Updated Family";
 
   //5.1
-  console.log("\n5.1 replace item with id '" + item.id + "'");
+  console.log(`\n5.1 replace item with id '${item.id}'`);
   const { body: updatedPerson } = await item.replace(person);
 
-  console.log("The '" + person.id + "' family has lastName '" + updatedPerson.lastName + "'");
-  console.log("The '" + person.id + "' family has " + updatedPerson.children.length + " children '");
+  console.log(`The '${person.id}' family has lastName '${updatedPerson.lastName}'`);
+  console.log(`The '${person.id}' family has ${updatedPerson.children.length} children '`);
 
   // 5.2
   console.log("\n5.2 trying to replace item when item has changed in the database");
@@ -190,7 +190,7 @@ async function init() {
 }
 
 async function handleError(error) {
-  console.log("\nAn error with code '" + error.code + "' has occurred:");
+  console.log(`\nAn error with code '${error.code}' has occurred:`);
   console.log("\t" + error.body || error);
 
   await finish();

--- a/samples/ItemManagement/app.js
+++ b/samples/ItemManagement/app.js
@@ -1,4 +1,4 @@
-// @ts-check
+﻿// @ts-check
 
 console.log();
 console.log("Azure Cosmos DB Node.js Samples");
@@ -47,21 +47,15 @@ async function run() {
 
   //1.
   console.log(`\n1. insert items in to database '${databaseId}' and container '${containerId}'`);
-  const itemDefs = getItemDefinitions();
-  const p = [];
-  for (const itemDef of itemDefs) {
-    p.push(container.items.create(itemDef));
-  }
-  await Promise.all(p);
-  console.log(itemDefs.length + " items created");
+  const promises = getItemDefinitions().map(itemDef => container.items.create(itemDef));
+  const items = await Promise.all(promises);
+  console.log(`${items.length} items created`);
 
   //2.
   console.log(`\n2. list items in container '${container.id}'`);
   const { result: itemDefList } = await container.items.readAll().toArray();
 
-  for (const itemDef of itemDefList) {
-    console.log(itemDef.id);
-  }
+  itemDefList.forEach(({ id }) => console.log(id));
 
   //3.1
   const item = container.item(itemDefList[0].id);

--- a/samples/ItemManagement/app.js
+++ b/samples/ItemManagement/app.js
@@ -8,7 +8,7 @@ console.log("ITEM MANAGEMENT");
 console.log("===================");
 console.log();
 
-const cosmos = require("../../lib/");
+const cosmos = require("../../lib/src");
 const CosmosClient = cosmos.CosmosClient;
 const config = require("../Shared/config");
 const fs = require("fs");

--- a/samples/ServerSideScripts/app.js
+++ b/samples/ServerSideScripts/app.js
@@ -10,7 +10,7 @@ console.log();
 /*jshint node:true */
 ("use strict");
 
-const cosmos = require("../../lib/");
+const cosmos = require("../../lib/src");
 const CosmosClient = cosmos.CosmosClient;
 const config = require("../Shared/config");
 const fs = require("fs");
@@ -59,7 +59,7 @@ async function run() {
   console.log("//////////////////////////////////");
 
   await database.delete();
-  console.log("Database and Collection DELETED"); 
+  console.log("Database and Collection DELETED");
   console.log("Demo finished");
 }
 

--- a/samples/UserManagement/app.js
+++ b/samples/UserManagement/app.js
@@ -7,7 +7,7 @@ console.log("USER MANAGEMENT");
 console.log("================");
 console.log();
 
-const cosmos = require("../../lib/");
+const cosmos = require("../../lib/src");
 const CosmosClient = cosmos.CosmosClient;
 const config = require("../Shared/config");
 const databaseId = config.names.database;

--- a/samples/UserManagement/app.js
+++ b/samples/UserManagement/app.js
@@ -1,4 +1,4 @@
-﻿// @ts-check
+// @ts-check
 console.log();
 console.log("Azure Cosmos DB Node.js Samples");
 console.log("================================");
@@ -146,6 +146,7 @@ async function getResourceToken(container, permission) {
  * @param {cosmos.Permission} permission
  */
 async function attemptAdminOperations(container, user, permission) {
+  /** @type any */
   const resourceTokens = await getResourceToken(container, permission);
   const client = new CosmosClient({
     endpoint,
@@ -180,6 +181,7 @@ async function attemptAdminOperations(container, user, permission) {
  * @param {cosmos.Permission} permission
  */
 async function attemptWriteWithReadPermissionAsync(container, user, permission) {
+  /** @type any */
   const resourceTokens = await getResourceToken(container, permission);
   const client = new CosmosClient({
     endpoint,

--- a/samples/UserManagement/app.js
+++ b/samples/UserManagement/app.js
@@ -1,4 +1,4 @@
-// @ts-check
+﻿// @ts-check
 console.log();
 console.log("Azure Cosmos DB Node.js Samples");
 console.log("================================");
@@ -57,31 +57,31 @@ async function init() {
   let permissionDef;
 
   const { body: itemDef, item: item1 } = await container1.items.create(itemSpec);
-  console.log(item1Name + "Created in " + container1Name + " !");
+  console.log(`${item1Name}Created in ${container1Name} !`);
 
   itemSpec = { id: item2Name };
 
   const { item: item2 } = await container1.items.create(itemSpec);
-  console.log(item2Name + "Created in " + container1Name + " !");
+  console.log(`${item2Name}Created in ${container1Name} !`);
 
   itemSpec = { id: item3Name };
 
   const { item: item3 } = await container2.items.create(itemSpec);
-  console.log(item3Name + " Created in " + container2Name + " !");
+  console.log(`${item3Name} Created in ${container2Name} !`);
 
   const { user: user1 } = await database.users.create(userDef);
-  console.log(user1Name + " created!");
+  console.log(`${user1Name} created!`);
 
   userDef = { id: user2Name };
 
   const { user: user2 } = await database.users.create(userDef);
-  console.log(user2Name + " created!");
+  console.log(`${user2Name} created!`);
 
   // Read Permission on container 1 for user1
   permissionDef = { id: "p1", permissionMode: cosmos.DocumentBase.PermissionMode.Read, resource: container1.url };
 
   const { ref: permission1 } = await user1.permissions.create(permissionDef);
-  console.log("Read only permission assigned to Thomas Andersen on container 1!");
+  console.log(`Read only permission assigned to Thomas Andersen on container 1!`);
 
   permissionDef = { id: "p2", permissionMode: cosmos.DocumentBase.PermissionMode.All, resource: item1.url };
 
@@ -101,7 +101,7 @@ async function init() {
   console.log("All permission assigned to Robin Wakefield on container 2!");
 
   const { result: permissions } = await user1.permissions.readAll().toArray();
-  console.log("Fetched permission for Thomas Andersen. Count is : " + permissions.length);
+  console.log(`Fetched permission for Thomas Andersen. Count is : ${permissions.length}`);
 
   return { user1, user2, container1, container2, permission1, permission2, permission3, permission4 };
 }
@@ -109,10 +109,10 @@ async function init() {
 //handle error
 async function handleError(error) {
   console.log();
-  console.log("An error with code '" + error.code + "' has occurred:");
-  console.log("\t" + error.body || error);
+  console.log(`An error with code '${error.code}' has occurred:`);
+  console.log(`\t${error.body || error}`);
   if (error.headers) {
-    console.log("\t" + JSON.stringify(error.headers));
+    console.log(`\t${JSON.stringify(error.headers)}`);
   }
   console.log();
   try {
@@ -160,16 +160,15 @@ async function attemptAdminOperations(container, user, permission) {
     .container(container.id)
     .items.readAll()
     .toArray();
-  console.log(user.id + " able to perform read operation on container 1");
+  console.log(`${user.id} able to perform read operation on container 1`);
 
   try {
     await client.databases.readAll().toArray();
   } catch (err) {
     console.log(
-      "Expected error occurred as " +
-        user.id +
-        " does not have access to get the list of databases. Error code : " +
+      `Expected error occurred as ${user.id} does not have access to get the list of databases. Error code : ${
         err.code
+      }`
     );
   }
 }
@@ -198,10 +197,9 @@ async function attemptWriteWithReadPermissionAsync(container, user, permission) 
       .items.upsert(itemDef);
   } catch (err) {
     console.log(
-      "Expected error occurred as " +
-        user.id +
-        " does not have access to insert an item in the first container. Error code : " +
-        err.code
+      `Expected error occurred as ${
+        user.id
+      } does not have access to insert an item in the first container. Error code : ${err.code}`
     );
   }
 }
@@ -232,7 +230,7 @@ async function attemptReadFromTwoCollections(container1, container2, user1, perm
     .container(container1.id)
     .items.readAll()
     .toArray();
-  console.log(user1.id + " able to read items from container 1. Document count is " + items1.length);
+  console.log(`${user1.id} able to read items from container 1. Document count is ${items1.length}`);
 
   const { result: items2 } = await client
     .database(databaseId)
@@ -240,7 +238,7 @@ async function attemptReadFromTwoCollections(container1, container2, user1, perm
     .items.readAll()
     .toArray();
 
-  console.log(user1.id + " able to read items from container 2. Document count is " + items2.length);
+  console.log(`${user1.id} able to read items from container 2. Document count is ${items2.length}`);
 
   const itemDef = { id: "not allowed" };
 
@@ -251,10 +249,9 @@ async function attemptReadFromTwoCollections(container1, container2, user1, perm
       .items.upsert(itemDef);
   } catch (err) {
     console.log(
-      "Expected error occurred as " +
-        user1.id +
-        " does not have access to insert an item in container 2. Error code : " +
+      `Expected error occurred as ${user1.id} does not have access to insert an item in container 2. Error code : ${
         err.code
+      }`
     );
   }
 }

--- a/samples/readme.md
+++ b/samples/readme.md
@@ -7,8 +7,9 @@ These samples demonstrate how to use the Node.js SDK to interact with the [Azure
 ### Quick steps:
 
 1.  Start the Cosmos DB emulator
-2.  `cd` into a given sample's directory
-3.  `npm start`
+2.  Follow the steps in [../dev.md](../dev.md) to build the SDK.
+3.  `cd` into a given sample's directory
+4.  `npm start`
 
 ### Debugging
 


### PR DESCRIPTION
1. Set the cwd when using the `Debug File` option in VS Code. This allows simple debugging of the samples. If this breaks debugging scenarios elsewhere, let me know and I can simply create a separate launch config called "Debug Sample File" or something.

2. Documentation tweak to be explicit that the SDK needs to be built before running the samples. It might seem obvious to devs on the team, but I figure being explicit is better than assuming external devs will realize this.

3. For whatever reason, Node refuses to load the `"main"` info from the `package.json` file located in the `lib` folder. This causes the samples to fail to run. I'm fixing this by explicitly pointing to the `lib/src` folder. This is the same place that the `package.json` file in the SDK root points, but I figure for samples, why not be explicit.

4. Typescript typechecking in the JS file finds an error using object literal. Force typescript to see an "any" variable to get rid of this non-error. 

5. Moving to template literals wherever possible.

6. Stylistic move away from for loops in ItemManagement demo. Switch to using `forEach` function on the arrays.