### PR TITLE
Fix ChangeFeed hasMoreResults

### DIFF
--- a/src/ChangeFeedIterator.ts
+++ b/src/ChangeFeedIterator.ts
@@ -75,10 +75,10 @@ export class ChangeFeedIterator<T> {
    * Gets an async iterator which will yield pages of results from Azure Cosmos DB.
    */
   public async *getAsyncIterator(): AsyncIterable<ChangeFeedResponse<Array<T & Resource>>> {
-    while (this.hasMoreResults) {
+    do {
       const result = await this.executeNext();
       yield result;
-    }
+    } while (this.hasMoreResults);
   }
 
   /**

--- a/src/ChangeFeedIterator.ts
+++ b/src/ChangeFeedIterator.ts
@@ -77,7 +77,9 @@ export class ChangeFeedIterator<T> {
   public async *getAsyncIterator(): AsyncIterable<ChangeFeedResponse<Array<T & Resource>>> {
     do {
       const result = await this.executeNext();
-      yield result;
+      if (result.count > 0) {
+        yield result;
+      }
     } while (this.hasMoreResults);
   }
 

--- a/src/ClientContext.ts
+++ b/src/ClientContext.ts
@@ -111,9 +111,9 @@ export class ClientContext {
       );
       this.applySessionToken(path, reqHeaders);
 
-      const { result, headers: resHeaders } = await this.requestHandler.get(endpoint, request, reqHeaders);
-      this.captureSessionToken(undefined, path, Constants.OperationTypes.Query, resHeaders);
-      return this.processQueryFeedResponse({ result, headers: resHeaders }, !!query, resultFn);
+      const response = await this.requestHandler.get(endpoint, request, reqHeaders);
+      this.captureSessionToken(undefined, path, Constants.OperationTypes.Query, response.headers);
+      return this.processQueryFeedResponse(response, !!query, resultFn);
     } else {
       initialHeaders[Constants.HttpHeaders.IsQuery] = "true";
       switch (this.cosmosClientOptions.queryCompatibilityMode) {
@@ -144,9 +144,8 @@ export class ClientContext {
       this.applySessionToken(path, reqHeaders);
 
       const response = await this.requestHandler.post(endpoint, request, query, reqHeaders);
-      const { result, headers: resHeaders } = response;
-      this.captureSessionToken(undefined, path, Constants.OperationTypes.Query, resHeaders);
-      return this.processQueryFeedResponse({ result, headers: resHeaders }, !!query, resultFn);
+      this.captureSessionToken(undefined, path, Constants.OperationTypes.Query, response.headers);
+      return this.processQueryFeedResponse(response, !!query, resultFn);
     }
   }
 
@@ -268,10 +267,10 @@ export class ClientContext {
     resultFn: (result: { [key: string]: any }) => any[]
   ): Response<any> {
     if (isQuery) {
-      return { result: resultFn(res.result), headers: res.headers };
+      return { result: resultFn(res.result), headers: res.headers, statusCode: res.statusCode };
     } else {
       const newResult = resultFn(res.result).map((body: any) => body);
-      return { result: newResult, headers: res.headers };
+      return { result: newResult, headers: res.headers, statusCode: res.statusCode };
     }
   }
 

--- a/src/retry/retryUtility.ts
+++ b/src/retry/retryUtility.ts
@@ -107,10 +107,11 @@ export class RetryUtility {
     requestOptions = this.modifyRequestOptions(requestOptions, url.parse(locationEndpoint));
     request.locationRouting.routeToLocation(locationEndpoint);
     try {
-      const { result, headers } = await (httpsRequest as Promise<Response<any>>);
-      headers[Constants.ThrottleRetryCount] = resourceThrottleRetryPolicy.currentRetryAttemptCount;
-      headers[Constants.ThrottleRetryWaitTimeInMs] = resourceThrottleRetryPolicy.cummulativeWaitTimeinMilliseconds;
-      return { result, headers };
+      const response = await (httpsRequest as Promise<Response<any>>);
+      response.headers[Constants.ThrottleRetryCount] = resourceThrottleRetryPolicy.currentRetryAttemptCount;
+      response.headers[Constants.ThrottleRetryWaitTimeInMs] =
+        resourceThrottleRetryPolicy.cummulativeWaitTimeinMilliseconds;
+      return response;
     } catch (err) {
       // TODO: any error
       let retryPolicy: IRetryPolicy = null;

--- a/src/test/integration/incrementalFeed.spec.ts
+++ b/src/test/integration/incrementalFeed.spec.ts
@@ -166,6 +166,12 @@ describe("Change Feed Iterator", function() {
         assert.equal(shouldHaveNoItems.length, 0, "there should be 0 results");
         const hasMoreResults = iterator.hasMoreResults;
         assert.equal(hasMoreResults, false, "hasMoreResults should be false when we read the whole page");
+
+        let count = 0;
+        for await (const page of iterator.getAsyncIterator()) {
+          ++count;
+        }
+        assert.equal(count, 0, "async iterator should return any results if there are none left to serve");
       });
     });
 

--- a/src/test/integration/incrementalFeed.spec.ts
+++ b/src/test/integration/incrementalFeed.spec.ts
@@ -4,21 +4,6 @@ import { Container, ContainerDefinition } from "../../client";
 import { Helper } from "../../common";
 import { getTestContainer, removeAllDatabases } from "../common/TestHelpers";
 
-function hasDupeKey(items: any[]) {
-  if (items && items.length === 0) {
-    return false;
-  }
-  const key = items[0].key;
-  let hasDupe = false;
-  for (const item of items) {
-    if (item.key !== key) {
-      hasDupe = true;
-      break;
-    }
-  }
-  return hasDupe;
-}
-
 describe("Change Feed Iterator", function() {
   this.timeout(process.env.MOCHA_TIMEOUT || 20000);
 
@@ -75,6 +60,11 @@ describe("Change Feed Iterator", function() {
         assert.equal(itemsWithContinuation.length, 1, "initial number of items should be equal 1");
         assert.equal(itemsWithContinuation[0].name, "xyz", "fetched item should have 'name: xyz'");
         assert.equal(itemsWithContinuation[0].id, item.id, "fetched item should be valid");
+
+        const { result: shouldHaveNoItems } = await iterator.executeNext();
+        assert.equal(shouldHaveNoItems.length, 0, "there should be 0 results");
+        const hasMoreResults = iterator.hasMoreResults;
+        assert.equal(hasMoreResults, false, "hasMoreResults should be false when we read the whole page");
       });
     });
 
@@ -119,6 +109,11 @@ describe("Change Feed Iterator", function() {
         assert.equal(itemsWithContinuation.length, 1, "initial number of items should be equal 1");
         assert.equal(itemsWithContinuation[0].name, "xyz", "fetched item should have 'name: xyz'");
         assert.equal(itemsWithContinuation[0].id, item.id, "fetched item should be valid");
+
+        const { result: shouldHaveNoItems } = await iterator.executeNext();
+        assert.equal(shouldHaveNoItems.length, 0, "there should be 0 results");
+        const hasMoreResults = iterator.hasMoreResults;
+        assert.equal(hasMoreResults, false, "hasMoreResults should be false when we read the whole page");
       });
     });
 
@@ -166,6 +161,11 @@ describe("Change Feed Iterator", function() {
         assert.equal(itemsAfterUpdate.length, 1, "initial number of items should be equal 1");
         assert.equal(itemsAfterUpdate[0].name, "xyz", "fetched item should have 'name: xyz'");
         assert.equal(itemsAfterUpdate[0].id, item.id, "fetched item should be valid");
+
+        const { result: shouldHaveNoItems } = await iterator.executeNext();
+        assert.equal(shouldHaveNoItems.length, 0, "there should be 0 results");
+        const hasMoreResults = iterator.hasMoreResults;
+        assert.equal(hasMoreResults, false, "hasMoreResults should be false when we read the whole page");
       });
     });
 
@@ -210,6 +210,11 @@ describe("Change Feed Iterator", function() {
         await container.items.create({ id: "item4" });
         const { result: itemsShouldHave2NewItems } = await iterator.executeNext();
         assert.equal(itemsShouldHave2NewItems.length, 2, "there should be 2 results");
+
+        const { result: shouldHaveNoItems } = await iterator.executeNext();
+        assert.equal(shouldHaveNoItems.length, 0, "there should be 0 results");
+        const hasMoreResults = iterator.hasMoreResults;
+        assert.equal(hasMoreResults, false, "hasMoreResults should be false when we read the whole page");
       });
     });
   });
@@ -281,6 +286,11 @@ describe("Change Feed Iterator", function() {
         assert.equal(itemsAfterUpdate.length, 1, "initial number of items should be equal 1");
         assert.equal(itemsAfterUpdate[0].name, "xyz", "fetched item should have 'name: xyz'");
         assert.equal(itemsAfterUpdate[0].id, item.id, "fetched item should be valid");
+
+        const { result: shouldHaveNoItems } = await iterator.executeNext();
+        assert.equal(shouldHaveNoItems.length, 0, "there should be 0 results");
+        const hasMoreResults = iterator.hasMoreResults;
+        assert.equal(hasMoreResults, false, "hasMoreResults should be false when we read the whole page");
       });
     });
 
@@ -322,7 +332,6 @@ describe("Change Feed Iterator", function() {
           prop: 1,
           key: "0"
         });
-        console.log(`createHeaders: ${createHeaders}`);
 
         const { result: itemsAfterCreate } = await iterator.executeNext();
         assert.equal(itemsAfterCreate.length, 1, "should have 1 item from create");
@@ -342,6 +351,10 @@ describe("Change Feed Iterator", function() {
         await container.items.create({ id: "item4", key: "1" });
         const { result: itemsShouldHave2NewItems } = await iterator.executeNext();
         assert.equal(itemsShouldHave2NewItems.length, 2, "there should be 2 results");
+        const { result: shouldHaveNoItems } = await iterator.executeNext();
+        assert.equal(shouldHaveNoItems.length, 0, "there should be 0 results");
+        const hasMoreResults = iterator.hasMoreResults;
+        assert.equal(hasMoreResults, false, "hasMoreResults should be false when we read the whole page");
       });
     });
   });


### PR DESCRIPTION
Fixes #244 

Response was dropping the status code thanks to some overzealous object destructuring and statusCode being optional on response. I don't want to make statusCode non-optional since it is a public type for query responses today.

In v3, where we are removing this type publicly, this will be a cleaner fix where I'll also make statusCode (and all those other properties) non-optional.