### PR TITLE
Remove agent socket defaults

### DIFF
--- a/src/CosmosClient.ts
+++ b/src/CosmosClient.ts
@@ -79,9 +79,7 @@ export class CosmosClient {
     if (!this.options.agent) {
       // Initialize request agent
       const requestAgentOptions: AgentOptions & tunnel.HttpsOverHttpsOptions & tunnel.HttpsOverHttpOptions = {
-        keepAlive: true,
-        maxSockets: 256,
-        maxFreeSockets: 256
+        keepAlive: true
       };
       if (!!this.options.connectionPolicy.ProxyUrl) {
         const proxyUrl = url.parse(this.options.connectionPolicy.ProxyUrl);


### PR DESCRIPTION
256 is low and arbitrary? We should use the node defaults https://nodejs.org/api/http.html#http_new_agent_options