### PR TITLE
Replace cross-fetch with node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -221,6 +221,15 @@
       "integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.1.7.tgz",
+      "integrity": "sha512-TZozHCDVrs0Aj1B9ZR5F4Q9MknDNcVd+hO5lxXOCzz07ELBey6s1gMUSZHUYHlPfRFKJFXiTnNuD7ePiI6S4/g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/priorityqueuejs": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/priorityqueuejs/-/priorityqueuejs-1.0.1.tgz",
@@ -927,15 +936,6 @@
       "requires": {
         "cross-spawn": "^6.0.5",
         "is-windows": "^1.0.0"
-      }
-    },
-    "cross-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.1.tgz",
-      "integrity": "sha512-qWtpgBAF8ioqBOddRD+pHhrdzm/UWOArkrlIU7c08DlNbOxo5GfUbSY2vr90ZypWf0raW+HNN1F38pi5CEOjiQ==",
-      "requires": {
-        "node-fetch": "2.3.0",
-        "whatwg-fetch": "3.0.0"
       }
     },
     "cross-spawn": {
@@ -5238,11 +5238,6 @@
         "loglevelnext": "^1.0.1",
         "uuid": "^3.1.0"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@microsoft/api-extractor": "6.3.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.5.8",
+    "@types/node-fetch": "2.1.7",
     "@types/priorityqueuejs": "^1.0.1",
     "@types/semaphore": "^1.1.0",
     "@types/sinon": "^4.3.3",
@@ -77,7 +78,7 @@
     "@azure/cosmos-sign": "1.0.2",
     "abort-controller": "2.0.3",
     "binary-search-bounds": "2.0.3",
-    "cross-fetch": "3.0.1",
+    "node-fetch": "2.3.0",
     "priorityqueuejs": "1.0.0",
     "semaphore": "1.0.5",
     "tslib": "^1.9.3"

--- a/src/request/RequestHandler.ts
+++ b/src/request/RequestHandler.ts
@@ -1,7 +1,7 @@
 import { AbortController } from "abort-controller";
-import fetch from "cross-fetch";
 import { Agent, OutgoingHttpHeaders } from "http";
 import { RequestOptions } from "https"; // TYPES ONLY
+import fetch from "node-fetch";
 import { parse } from "url";
 import { Constants, HTTPMethod } from "../common/constants";
 import { ConnectionPolicy } from "../documents";


### PR DESCRIPTION
cross-fetch will automatically ship a fetch polyfill to all browsers. node-fetch has better behavior which is to rely on a user-supplied polyfill in the browser.