### PR TITLE
Plugin implementation

### DIFF
--- a/src/CosmosClientOptions.ts
+++ b/src/CosmosClientOptions.ts
@@ -1,5 +1,6 @@
 import { AuthOptions } from "./auth";
 import { ConnectionPolicy, ConsistencyLevel } from "./documents";
+import { PluginConfig } from "./plugins/Plugin";
 import { CosmosHeaders } from "./queryExecutionContext/CosmosHeaders";
 
 // We expose our own Agent interface to avoid taking a dependency on and leaking node types. This interface should mirror the node Agent interface
@@ -31,4 +32,5 @@ export interface CosmosClientOptions {
    * Use an agent such as https://github.com/TooTallNate/node-proxy-agent if you need to connect to Cosmos via a proxy
    */
   agent?: Agent;
+  plugins?: PluginConfig[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,10 +24,13 @@ export {
 export { UniqueKeyPolicy, UniqueKey } from "./client/Container/UniqueKeyPolicy";
 export { Constants } from "./common";
 export { RetryOptions } from "./retry";
-export { Response, RequestOptions, FeedOptions, ErrorResponse } from "./request";
+export { Response, RequestOptions, FeedOptions, ErrorResponse, ResourceResponse } from "./request";
+export { FeedResponse } from "./request/FeedResponse";
+export { RequestContext } from "./request/RequestContext";
 export { CosmosHeaders, SqlParameter, SqlQuerySpec } from "./queryExecutionContext";
 export { QueryIterator } from "./queryIterator";
 export * from "./queryMetrics";
 export { CosmosClient } from "./CosmosClient";
 export { CosmosClientOptions } from "./CosmosClientOptions";
 export * from "./client";
+export { Next, Plugin, PluginConfig, PluginOn } from "./plugins/Plugin";

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -1,20 +1,60 @@
 import { RequestContext } from "../request/RequestContext";
 import { Response } from "../request/Response";
 
+/**
+ * Used to specify which type of events to execute this plug in on.
+ */
 export enum PluginOn {
+  /**
+   * Will be executed per network request
+   */
   request = "request",
+  /**
+   * Will be executed per API operation
+   */
   operation = "operation"
 }
 
+/**
+ * Specifies which event to run for the specified plugin
+ */
 export interface PluginConfig {
+  /**
+   * The event to run the plugin on
+   */
   on: keyof typeof PluginOn;
+  /**
+   * The plugin to run
+   */
   plugin: Plugin<any>;
 }
 
+/**
+ * Plugins allow you to customize the behavior of the SDk with additional logging, retry, or additional functionality.
+ *
+ * A plugin is a function which returns a Promise<Response<T>>, and is passed a RequestContext and Next object.
+ *
+ * Next is a function which takes in requestContext returns a promise. You must await/then that promise which will contain the response from further plugins,
+ * allowing you to log those results or handle errors.
+ *
+ * RequestContext is an object which controls what operation is happening, against which endpoint, and more. Modifying this and passing it along via next is how
+ * you modify future SDK behavior.
+ */
 export type Plugin<T> = (context: RequestContext, next: Next<T>) => Promise<Response<T>>;
 
+/**
+ * Next is a function which takes in requestContext returns a promise. You must await/then that promise which will contain the response from further plugins,
+ * allowing you to log those results or handle errors.
+ */
 export type Next<T> = (context: RequestContext) => Promise<Response<T>>;
 
+/**
+ * @internal
+ * @hidden
+ * @param requestContext
+ * @param next
+ * @param on
+ */
 export async function executePlugins(
   requestContext: RequestContext,
   next: Plugin<any>,
@@ -39,23 +79,3 @@ export async function executePlugins(
     return requestContext.plugins[level].plugin(requestContext, _);
   }
 }
-
-// const client = new CosmosClient({
-//   plugins: [
-//     {
-//       on: "Request",
-//       plugin: (requestContext: RequestContext, next: Plugin['next']) => {
-//         console.log(requestContext.endpoint);
-//         return next(requestContext);
-//       }
-//     },
-//     {
-//       on: "Request",
-//       plugin: async (requestContext: RequestContext, next: Plugin['next']') => {
-//         const response = await next(requestContext);
-//         console.log(response.headers.requestUnits);
-//         return response;
-//       }
-//     }
-//   ]
-// });

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -1,0 +1,62 @@
+import { RequestContext } from "../request/RequestContext";
+import { Response } from "../request/Response";
+
+export enum PluginOn {
+  request = "request",
+  operation = "operation"
+}
+
+export interface PluginConfig {
+  on: keyof typeof PluginOn;
+  plugin: Plugin<any>;
+}
+
+export type Plugin<T> = (
+  context: RequestContext,
+  next: (context: RequestContext) => Promise<Response<T>>
+) => Promise<Response<T>>;
+
+export async function executePlugins(
+  requestContext: RequestContext,
+  next: Plugin<any>,
+  on: PluginOn
+): Promise<Response<any>> {
+  if (!requestContext.plugins) {
+    return next(requestContext, undefined);
+  }
+  let level = 0;
+  function _(inner: RequestContext): Promise<Response<any>> {
+    if (++level >= inner.plugins.length) {
+      return next(requestContext, undefined);
+    } else if (inner.plugins[level].on !== on) {
+      return _(requestContext);
+    } else {
+      return inner.plugins[level].plugin(inner, _);
+    }
+  }
+  if (requestContext.plugins[level].on !== on) {
+    return _(requestContext);
+  } else {
+    return requestContext.plugins[level].plugin(requestContext, _);
+  }
+}
+
+// const client = new CosmosClient({
+//   plugins: [
+//     {
+//       on: "Request",
+//       plugin: (requestContext: RequestContext, next: Plugin['next']) => {
+//         console.log(requestContext.endpoint);
+//         return next(requestContext);
+//       }
+//     },
+//     {
+//       on: "Request",
+//       plugin: async (requestContext: RequestContext, next: Plugin['next']') => {
+//         const response = await next(requestContext);
+//         console.log(response.headers.requestUnits);
+//         return response;
+//       }
+//     }
+//   ]
+// });

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -11,10 +11,9 @@ export interface PluginConfig {
   plugin: Plugin<any>;
 }
 
-export type Plugin<T> = (
-  context: RequestContext,
-  next: (context: RequestContext) => Promise<Response<T>>
-) => Promise<Response<T>>;
+export type Plugin<T> = (context: RequestContext, next: Next<T>) => Promise<Response<T>>;
+
+export type Next<T> = (context: RequestContext) => Promise<Response<T>>;
 
 export async function executePlugins(
   requestContext: RequestContext,
@@ -25,7 +24,7 @@ export async function executePlugins(
     return next(requestContext, undefined);
   }
   let level = 0;
-  function _(inner: RequestContext): Promise<Response<any>> {
+  const _: Next<any> = (inner: RequestContext): Promise<Response<any>> => {
     if (++level >= inner.plugins.length) {
       return next(requestContext, undefined);
     } else if (inner.plugins[level].on !== on) {
@@ -33,7 +32,7 @@ export async function executePlugins(
     } else {
       return inner.plugins[level].plugin(inner, _);
     }
-  }
+  };
   if (requestContext.plugins[level].on !== on) {
     return _(requestContext);
   } else {

--- a/src/request/RequestContext.ts
+++ b/src/request/RequestContext.ts
@@ -3,6 +3,7 @@ import { HTTPMethod, OperationType, ResourceType } from "../common";
 import { Agent } from "../CosmosClientOptions";
 import { ConnectionPolicy } from "../documents";
 import { GlobalEndpointManager } from "../globalEndpointManager";
+import { PluginConfig } from "../plugins/Plugin";
 import { CosmosHeaders } from "../queryExecutionContext/CosmosHeaders";
 import { FeedOptions } from "./FeedOptions";
 import { LocationRouting } from "./LocationRouting";
@@ -25,4 +26,5 @@ export interface RequestContext {
   method: HTTPMethod;
   partitionKeyRangeId?: string;
   options: FeedOptions | RequestOptions;
+  plugins: PluginConfig[];
 }

--- a/src/request/RequestHandler.ts
+++ b/src/request/RequestHandler.ts
@@ -2,6 +2,7 @@ import { AbortController } from "abort-controller";
 import fetch, { RequestInit, Response } from "node-fetch";
 import { trimSlashes } from "../common";
 import { Constants } from "../common/constants";
+import { executePlugins, PluginOn } from "../plugins/Plugin";
 import * as RetryUtility from "../retry/retryUtility";
 import { ErrorResponse } from "./ErrorResponse";
 import { bodyFromData } from "./request";
@@ -12,6 +13,10 @@ import { TimeoutError } from "./TimeoutError";
 /** @hidden */
 
 export async function executeRequest(requestContext: RequestContext) {
+  return executePlugins(requestContext, httpRequest, PluginOn.request);
+}
+
+async function httpRequest(requestContext: RequestContext) {
   const controller = new AbortController();
   const signal = controller.signal;
 

--- a/test/functional/plugin.spec.ts
+++ b/test/functional/plugin.spec.ts
@@ -1,0 +1,128 @@
+import { CosmosClient } from "../../dist-esm";
+import { RequestContext } from "../../dist-esm/request/RequestContext";
+import { Plugin, Next } from "../../dist-esm/plugins/Plugin";
+
+import * as assert from "assert";
+
+describe("Plugin", function() {
+  it("should handle all requests", async function() {
+    const successResponse = {
+      headers: {},
+      statusCode: 200,
+      result: {
+        message: "yay"
+      }
+    };
+    let requestCount = 0;
+    const FAILCOUNT = 2;
+    const sometimesThrow: Plugin<any> = async (context: RequestContext, next: Next<any>) => {
+      requestCount++;
+      if (context.path.includes("dbs") && requestCount <= FAILCOUNT) {
+        throw {
+          code: "ECONNRESET"
+        };
+      }
+      return successResponse;
+    };
+
+    const client = new CosmosClient({
+      endpoint: "https://faaaaaaaaaaaaake.com",
+      key: "THIS IS A FAKE KEY",
+      plugins: [
+        {
+          on: "request",
+          plugin: sometimesThrow
+        }
+      ]
+    });
+    const response = await client.database("foo").read();
+    assert.equal(requestCount, FAILCOUNT + 1); // Get Database Account + FAILED GET Database + Get Database
+    assert.notEqual(response, undefined);
+    assert.equal(response.statusCode, successResponse.statusCode);
+    assert.deepEqual(response.resource, successResponse.result);
+  });
+
+  it("should handle all operations", async function() {
+    const successResponse = {
+      headers: {},
+      statusCode: 200,
+      result: {
+        message: "yay"
+      }
+    };
+    let requestCount = 0;
+    const alwaysSucceed: Plugin<any> = async (context: RequestContext, next: Next<any>) => {
+      requestCount++;
+      return successResponse;
+    };
+    const alwaysThrow: Plugin<any> = async (context: RequestContext, next: Next<any>) => {
+      throw new Error("I always throw!");
+    };
+
+    const client = new CosmosClient({
+      endpoint: "https://faaaaaaaaaaaaake.com",
+      key: "THIS IS A FAKE KEY",
+      plugins: [
+        {
+          on: "request",
+          plugin: alwaysThrow // I'll never be called since operation will always succeed.
+        },
+        {
+          on: "operation",
+          plugin: alwaysSucceed
+        }
+      ]
+    });
+    const response = await client.database("foo").read();
+    assert.equal(requestCount, 2); // Get Database Account + Get Database
+    assert.notEqual(response, undefined);
+    assert.equal(response.statusCode, successResponse.statusCode);
+    assert.deepEqual(response.resource, successResponse.result);
+  });
+
+  it("should allow next to be called", async function() {
+    const successResponse = {
+      headers: {},
+      statusCode: 200,
+      result: {
+        message: "yay"
+      }
+    };
+    let innerRequestCount = 0;
+    const alwaysSucceed: Plugin<any> = async (context: RequestContext, next: Next<any>) => {
+      innerRequestCount++;
+      return successResponse;
+    };
+
+    let requestCount = 0;
+    let responseCount = 0;
+    const counts: Plugin<any> = async (context: RequestContext, next: Next<any>) => {
+      requestCount++;
+      const response = await next(context);
+      responseCount++;
+      return response;
+    };
+
+    const client = new CosmosClient({
+      endpoint: "https://faaaaaaaaaaaaake.com",
+      key: "THIS IS A FAKE KEY",
+      plugins: [
+        {
+          on: "operation",
+          plugin: counts // I'll never be called since operation will always succeed.
+        },
+        {
+          on: "operation",
+          plugin: alwaysSucceed
+        }
+      ]
+    });
+    const response = await client.database("foo").read();
+    assert.equal(requestCount, 2); // Get Database Account + Get Database
+    assert.equal(responseCount, 2); // Get Database Account + Get Database
+    assert.equal(innerRequestCount, 2); // Get Database Account + Get Database
+    assert.notEqual(response, undefined);
+    assert.equal(response.statusCode, successResponse.statusCode);
+    assert.deepEqual(response.resource, successResponse.result);
+  });
+});


### PR DESCRIPTION
This implements Plugins which allows users to listen and/or modify requests. 

Plugins are just functions which return a `Promise<Response<T>>` and take in a `RequestContext` and `(requestContext: RequestContext) => Promise<Response<T>>` function, which can be awaited to call the next step and wait for the response.

There are currently two categories of plugins, `Operation` and `Request`. These allow you to register Plugins for these two specific operations, independently. `Operation` is called once(*) for every operation(**). `Request` is called once (*) for every next work call.

(*) - It will be called once for every attempt, so if a higher level plugin attempts to retry the operation/request or fork the operation (speculative retry), it will be called more than once for that given operation/request.

(**) - Right now, getGlobalDatabaseAccount is considered its own operation, which means more than 1 operation callback could be called if refresh gets called (which is does on instantiation). This should be looked at...

Here's an example of two plugins, one always succeeds with a fixed body (no network operations would happen in either case:
```typescript
    const alwaysSucceed: Plugin<any> = async (context: RequestContext, next: Next<any>) => {
      requestCount++;
      return { statusCode: 200, result: { "message": "yay" } };
    };
    const alwaysThrow: Plugin<any> = async (context: RequestContext, next: Next<any>) => {
      throw new Error("I always throw!");
    };
```
The case above is interesting since alwaysSucceed is registered as an operation, which will be executed before all request types, so always throw will never be called.

You register them like so:

```typescript
const client = new CosmosClient({
      endpoint: "https://faaaaaaaaaaaaake.com",
      key: "THIS IS A FAKE KEY",
      plugins: [
        {
          on: "request",
          plugin: alwaysThrow // I'll never be called since operation will always succeed.
        },
        {
          on: "operation",
          plugin: alwaysSucceed
        }
      ]
    });
```

If you want to just do something and then continue on with the request, you can call and await `next()`
```typescript
    let requestCount = 0;
    let responseCount = 0;
    const counts: Plugin<any> = async (context: RequestContext, next: Next<any>) => {
      requestCount++;
      const response = await next(context);
      responseCount++;
      return response;
    };
```

TODOs:

- [x] Make sure the public types are emitted from the package
- [x] TypeDocs
- [ ] <strike>Samples</strike> Created tracking item: https://github.com/Azure/azure-cosmos-js/issues/300
- [x] More tests

Open issues:

- Should we be calling user operation plugins on internal calls like getDatabaseAccount?

