### PR TITLE
Remove test catch all for .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,5 +271,4 @@ ts-test/*.js
 test/**/*.js
 test/**/*.js.map
 test/**/*.d.ts
-test/
 tsconfig.tsbuildinfo


### PR DESCRIPTION
Have to force add tests, but the other filters catch the random .js/.js.map files.