### PR TITLE
Add quick reference to install syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ helloCosmos().catch(err => {
 });
 ```
 
+## Install via NPM
+You can install the npm package using the following command:
+
+```bash
+npm install @azure/cosmos
+```
+
 ## Useful links
 
 - [Welcome to Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/community)


### PR DESCRIPTION
Readers can infer the install command from the first line of the sample script, but this makes it easy to find as you are scanning the README.