### PR TITLE
Fix browser atob errors

### DIFF
--- a/src/session/sessionContainer.ts
+++ b/src/session/sessionContainer.ts
@@ -74,7 +74,9 @@ export class SessionContainer {
   private validateOwnerID(ownerId: string) {
     // If ownerId contains exactly 8 bytes it represents a unique database+collection identifier. Otherwise it represents another resource
     // The first 4 bytes are the database. The last 4 bytes are the collection.
-    return atob(ownerId).length === 8;
+    // Cosmos rids potentially contain "-" which is an invalid character in the browser atob implementation
+    // See https://en.wikipedia.org/wiki/Base64#Filenames
+    return atob(ownerId.replace(/-/g, "/")).length === 8;
   }
 
   private getPartitionKeyRangeIdToTokenMap(collectionName: string): Map<string, VectorSessionToken> {

--- a/test/unit/sessionContainer.spec.ts
+++ b/test/unit/sessionContainer.spec.ts
@@ -4,9 +4,9 @@ import { CosmosHeaders } from "../../dist-esm/queryExecutionContext/CosmosHeader
 import { SessionContainer } from "../../dist-esm/session/sessionContainer";
 import { SessionContext } from "../../dist-esm/session/SessionContext";
 
-describe("SessionContainer", function() {
+describe.only("SessionContainer", function() {
   const collectionLink = "dbs/testDatabase/colls/testCollection";
-  const collectionId = "oWxIAN48yN0=";
+  const collectionRid = "-EdBAKsiRLM=";
 
   it("set/get/delete", function() {
     const sc = new SessionContainer();
@@ -15,7 +15,7 @@ describe("SessionContainer", function() {
 
     const nameBasedRequest: SessionContext = {
       isNameBased: true,
-      resourceId: null,
+      resourceId: collectionRid,
       resourceAddress: "/" + collectionLink + "/",
       resourceType: ResourceType.item,
       operationType: OperationType.Create
@@ -23,7 +23,7 @@ describe("SessionContainer", function() {
 
     const resHeadersNameBased: CosmosHeaders = {};
     resHeadersNameBased[Constants.HttpHeaders.OwnerFullName] = collectionLink;
-    resHeadersNameBased[Constants.HttpHeaders.OwnerId] = collectionId;
+    resHeadersNameBased[Constants.HttpHeaders.OwnerId] = collectionRid;
     resHeadersNameBased[Constants.HttpHeaders.SessionToken] = tokenString;
 
     // Add a token and get new token, should be equal

--- a/test/unit/sessionContainer.spec.ts
+++ b/test/unit/sessionContainer.spec.ts
@@ -4,7 +4,7 @@ import { CosmosHeaders } from "../../dist-esm/queryExecutionContext/CosmosHeader
 import { SessionContainer } from "../../dist-esm/session/sessionContainer";
 import { SessionContext } from "../../dist-esm/session/SessionContext";
 
-describe.only("SessionContainer", function() {
+describe("SessionContainer", function() {
   const collectionLink = "dbs/testDatabase/colls/testCollection";
   const collectionRid = "-EdBAKsiRLM=";
 


### PR DESCRIPTION
Cosmos bas64 rids can contain "-" which the browser atob function sees as an invalid encoding