### PR TITLE
Prevent webpack from resolving modules called with `require`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/index.js",
   "browser": {
-    "dist-esm/request/defaultAgent.js": "dist-esm/request/defaultAgent.browser.js"
+    "./dist-esm/request/defaultAgent.js": "./dist-esm/request/defaultAgent.browser.js"
   },
   "types": "./dist/index.d.ts",
   "engine": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/index.js",
   "browser": {
-    "dist-esm/request/defaultAgent.ts": "dist-esm/request/defaultAgent.browser.ts"
+    "dist-esm/request/defaultAgent.js": "dist-esm/request/defaultAgent.browser.js"
   },
   "types": "./dist/index.d.ts",
   "engine": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "author": "Microsoft Corporation",
   "main": "./dist/index.js",
   "module": "./dist-esm/index.js",
+  "browser": {
+    "dist-esm/request/defaultAgent.ts": "dist-esm/request/defaultAgent.browser.ts"
+  },
   "types": "./dist/index.d.ts",
   "engine": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "version": "3.0.2",
   "author": "Microsoft Corporation",
   "main": "./dist/index.js",
-  "module": "./dist-esm/src/index.js",
+  "module": "./dist-esm/index.js",
   "types": "./dist/index.d.ts",
   "engine": {
     "node": ">=6.0.0"

--- a/src/request/defaultAgent.browser.ts
+++ b/src/request/defaultAgent.browser.ts
@@ -1,0 +1,9 @@
+import { Agent } from "http";
+/**
+ * @ignore
+ */
+export let defaultHttpAgent: Agent;
+/**
+ * @ignore
+ */
+export let defaultHttpsAgent: Agent;

--- a/src/request/defaultAgent.ts
+++ b/src/request/defaultAgent.ts
@@ -11,13 +11,13 @@ export let defaultHttpAgent: Agent;
 export let defaultHttpsAgent: Agent;
 
 if (isNode) {
-  // tslint:disable-next-line:no-eval
-  const https = eval("require")("https");
+  // tslint:disable-next-line:no-var-requires
+  const https = require("https");
   defaultHttpsAgent = new https.Agent({
     keepAlive: true
   });
-  // tslint:disable-next-line:no-eval
-  const http = eval("require")("http");
+  // tslint:disable-next-line:no-var-requires
+  const http = require("http");
   defaultHttpAgent = new http.Agent({
     keepAlive: true
   });

--- a/src/request/defaultAgent.ts
+++ b/src/request/defaultAgent.ts
@@ -11,13 +11,13 @@ export let defaultHttpAgent: Agent;
 export let defaultHttpsAgent: Agent;
 
 if (isNode) {
-  // tslint:disable-next-line:no-var-requires
-  const https = require("https");
+  // tslint:disable-next-line:no-eval
+  const https = eval("require")("https");
   defaultHttpsAgent = new https.Agent({
     keepAlive: true
   });
-  // tslint:disable-next-line:no-var-requires
-  const http = require("http");
+  // tslint:disable-next-line:no-eval
+  const http = eval("require")("http");
   defaultHttpAgent = new http.Agent({
     keepAlive: true
   });


### PR DESCRIPTION
This fixes 3.0.2 which is currently broken for webpack users

1. In nodejs envs, we need to set a default agent with keepAlive: true. It results in a ~2x perf improvement
2. The only way to do this with node API is to dynamically require `http` or `https` and construct the agent
3. This doesn't matter for browser users, but we need to prevent them from loading the code and node builtin modules
4. By default, webpack will see `require` and attempt to resolve the module
5. We can trick webpack into not doing this with `eval('require')`