### PR TITLE
Remove disableSSLVerification

### DIFF
--- a/src/documents/ConnectionPolicy.ts
+++ b/src/documents/ConnectionPolicy.ts
@@ -15,11 +15,6 @@ export interface ConnectionPolicy {
   /** RetryOptions object which defines several configurable properties used during retry. */
   retryOptions?: RetryOptions;
   /**
-   * Flag to disable SSL verification for the requests. SSL verification is enabled by default. Don't set this when targeting production endpoints.
-   * This is intended to be used only when targeting emulator endpoint to avoid failing your requests with SSL related error.
-   */
-  disableSSLVerification?: boolean;
-  /**
    * The flag that enables writes on any locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service.
    * Default is `false`.
    */
@@ -35,6 +30,5 @@ export const defaultConnectionPolicy = Object.freeze({
   enableEndpointDiscovery: true,
   preferredLocations: [],
   retryOptions: {},
-  disableSSLVerification: false,
   useMultipleWriteLocations: true
 });

--- a/test/integration/sslVerification.spec.ts
+++ b/test/integration/sslVerification.spec.ts
@@ -1,33 +1,30 @@
 ﻿import assert from "assert";
 import { CosmosClient } from "../../dist-esm";
 import { getTestDatabase } from "../common/TestHelpers";
+import https from "https";
 
-const endpoint = "https://localhost:443";
+const endpoint = "https://localhost:8081";
 const masterKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
-// TODO: Skipping these tests for now until we find a way to run these tests in a seperate nodejs process
-// Currently all tests are run in same process so we cannot update the environment variables for different tests
-// This test runs fine when run independently but fails when run along with rest of the tests.
-describe.skip("Validate SSL verification check for emulator", function() {
-  it("nativeApi Client Should throw exception", async function() {
+describe.only("Validate SSL verification check for emulator", function() {
+  it("should throw exception", async function() {
     try {
       const client = new CosmosClient({ endpoint, key: masterKey });
       // create database
       await getTestDatabase("ssl verification", client);
     } catch (err) {
       // connecting to emulator should throw SSL verification error,
-      // unless you explicitly disable it via connectionPolicy.DisableSSLVerification
       assert.equal(err.code, "DEPTH_ZERO_SELF_SIGNED_CERT", "client should throw exception");
     }
   });
 
-  it("nativeApi Client Should successfully execute request", async function() {
+  it("disable ssl check via agent", async function() {
     const client = new CosmosClient({
       endpoint,
       key: masterKey,
-      connectionPolicy: {
-        disableSSLVerification: true
-      }
+      agent: new https.Agent({
+        rejectUnauthorized: false
+      })
     });
 
     // create database

--- a/test/integration/sslVerification.spec.ts
+++ b/test/integration/sslVerification.spec.ts
@@ -6,7 +6,7 @@ import https from "https";
 const endpoint = "https://localhost:8081";
 const masterKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
-describe.only("Validate SSL verification check for emulator", function() {
+describe("Validate SSL verification check for emulator", function() {
   it("should throw exception", async function() {
     try {
       const client = new CosmosClient({ endpoint, key: masterKey });


### PR DESCRIPTION
This option no longer works in v3. I think we should remove it and point to two better options:

1. Disable by passing a custom agent:

``` js
    const client = new CosmosClient({
      endpoint,
      key,
      agent: new https.Agent({
        rejectUnauthorized: false
      })
    });
```

2. Globally disable SSL Checks:

``` js
    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
    const client = new CosmosClient({
      endpoint,
      key
    });
```

In a different PR, we could check to see if the emulator is the target endpoint and do this automatically. It is a bit of a friction point for users just starting out with the emulator.
