### PR TITLE
Add stale issue action

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,16 @@
+name: "Close stale issues"
+
+on:
+  schedule:
+  - cron: "0 * * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        days-before-stale: 30
+        days-before-close: 5


### PR DESCRIPTION
Adds an action which marks issues as stale and then closes them. If you remove the stale label, it doesn't delete it.

See https://github.com/marketplace/actions/close-stale-issues

Also commented on an issue to add an exempt label to ignore issues